### PR TITLE
Set PHP max upload size to 70m, accordingly to Scalingo routers

### DIFF
--- a/conf/nginx/base.conf.erb
+++ b/conf/nginx/base.conf.erb
@@ -27,7 +27,7 @@ http {
     error_log logs/error.log notice;
     access_log logs/access.log specialLog;
 
-    client_max_body_size 100m;
+    client_max_body_size 75m;
     client_body_timeout 600s;
 
     upstream php {

--- a/conf/php/php.ini
+++ b/conf/php/php.ini
@@ -20,5 +20,5 @@ opcache.validate_timestamps=off
 opcache.fast_shutdown=0
 opcache.enable_cli=1
 
-upload_max_filesize = 70M
-post_max_size = 70M
+upload_max_filesize = 75M
+post_max_size = 75M

--- a/conf/php/php.ini
+++ b/conf/php/php.ini
@@ -19,3 +19,6 @@ opcache.max_accelerated_files=4000
 opcache.validate_timestamps=off
 opcache.fast_shutdown=0
 opcache.enable_cli=1
+
+upload_max_filesize = 70M
+post_max_size = 70M


### PR DESCRIPTION
Fixes #39