### PR TITLE
Add CodeIgniter log files support

### DIFF
--- a/frameworks/codeigniter
+++ b/frameworks/codeigniter
@@ -12,6 +12,9 @@ case "$1" in
             exit 1
         fi
         ;;
+    get-log-files)
+        echo "application/logs/log-$(date +%Y-%m-%d).php"
+        ;;
     compile)
         echo "-----> Setting up CodeIgniter"
         cp "$basedir/../conf/nginx/codeigniter.conf.erb" "$BUILD_DIR/conf/site.conf.erb"


### PR DESCRIPTION
CodeIgniter outputs logs in a file located in `application/logs/log-2018-07-30.php`. 