### PR TITLE
Add FTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ support.
 * Lightweight stack compared to Apache-ModPHP
 * Composer support
 * Various frameworks support out of the box (no configuration)
-* Dynamic installing of [supported extensions](support/ext) listed as `ext-` requirments in `composer.json`.
+* Dynamic installing of [supported extensions](support/ext) listed as `ext-` requirements in `composer.json`.
 
 ## How to use it
 
-This buildpack is used automatically by Scalingo. So you juste need to create a
+This buildpack is used automatically by Scalingo. So you just need to create a
 PHP application and to deploy it.
 
 ```

--- a/support/ext-internal/ftp
+++ b/support/ext-internal/ftp
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+php_version=$1
+zend_api_version=$2
+php_src_dir=$3
+
+pushd $php_src_dir/php-${php_version}/ext/ftp
+
+export PATH=$PATH:/app/vendor/php/bin
+
+phpize
+./configure --with-ftp
+make
+make install
+
+cp modules/ftp.so "$EXT_DIR"
+popd
+
+echo "extension=ftp.so" > "$PREFIX/etc/conf.d/ftp.ini"

--- a/support/package_php
+++ b/support/package_php
@@ -91,6 +91,7 @@ mkdir -p "/app/vendor/php/zlib" "/app/vendor/libmcrypt" \
 --enable-pcntl \
 --enable-sockets \
 --enable-bcmath \
+--enable-ftp \
 --with-readline \
 --with-mcrypt=/app/vendor/libmcrypt \
 --disable-debug \

--- a/support/package_php
+++ b/support/package_php
@@ -91,7 +91,6 @@ mkdir -p "/app/vendor/php/zlib" "/app/vendor/libmcrypt" \
 --enable-pcntl \
 --enable-sockets \
 --enable-bcmath \
---enable-ftp \
 --with-readline \
 --with-mcrypt=/app/vendor/libmcrypt \
 --disable-debug \


### PR DESCRIPTION
Fix #47

Cf. phpinfo here: https://php7-support.scalingo.io/

In the section "Module Authors", there is a credit for the FTP module which was not present before the patch.