### PR TITLE
Improve PHP version detection and switch to 7.2 as a default

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,6 +67,18 @@ function detect_framework() {
   done
 }
 
+function best_php_version() {
+  local require_php=""
+  if [ -f "$BUILD_DIR/composer.json" ] ; then
+    for key in ".require.php" ".config.platform.php" ".extra.${composer_extra_key}.engines.php" ; do
+      require_php=$(jq --raw-output "${key} // \"\"" < "$BUILD_DIR/composer.json")
+      [ -n "${require_php}" ] && break
+    done
+  fi
+  [ -z "${require_php}" ] && require_php="$DEFAULT_PHP"
+  curl --fail --location --silent "${SEMVER_SERVER}/php-scalingo/resolve/${require_php}"
+}
+
 function php_api_version() {
   basename "$(php-config --extension-dir)" | tr '-' ' ' | cut -f 5 -d ' '
 }
@@ -89,12 +101,6 @@ function package_framework() {
 
 function package_nginx_version() {
   jq --raw-output ".extra.${composer_extra_key}.engines.nginx // \"default\"" < "$BUILD_DIR/composer.json"
-}
-
-function package_php_version() {
-  local require_php=$(jq --raw-output ".require.php // \"${DEFAULT_PHP}\"" < "$BUILD_DIR/composer.json")
-  require_php=$(curl --fail --location --silent "${SEMVER_SERVER}/php-scalingo/resolve/${require_php}")
-  jq --raw-output ".extra.${composer_extra_key}.engines.php // \"${require_php}\"" < "$BUILD_DIR/composer.json"
 }
 
 function package_php_config() {
@@ -147,7 +153,7 @@ export PATH="$BUILD_DIR/bin:$PATH"
 curl --fail "${SWIFT_URL}/jq/jq" -L -s -o - > "$BUILD_DIR/bin/jq"
 chmod +x "$BUILD_DIR/bin/jq"
 
-DEFAULT_PHP=$(curl --fail --location --silent "${SEMVER_SERVER}/php-scalingo/resolve/~5.6")
+DEFAULT_PHP="~7.2"
 DEFAULT_NGINX="1.10.1"
 
 AVAILABLE_PHP_VERSIONS=$(curl "${SWIFT_URL}/manifest.php" 2> /dev/null)
@@ -179,7 +185,7 @@ if [ -f "$BUILD_DIR/composer.json" ]; then
     composer_extra_key="heroku"
   fi
 
-  PHP_VERSION=$(package_php_version)
+  PHP_VERSION=$(best_php_version)
   NGINX_VERSION=$(package_nginx_version)
   DOCUMENT_ROOT=$(package_document_root)
   INDEX_DOCUMENT=$(package_index_file)


### PR DESCRIPTION
* `composer.json` can now have these keys: `.require.php`,
`.config.platform.php`, `.extra.paas.engines.php`, in this order of priority.
This ensure the retrocompatibility + accept what seems to be a standard
from the community:

References:

* https://getcomposer.org/doc/06-config.md
* https://andy-carter.com/blog/composer-php-platform
* http://syrwebdev.com/composer/2015/01/07/using-composer-to-require-php-modules.html