### PR TITLE
PHP-FPM is never run as root, so remove user instruction to avoid warning

### DIFF
--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -127,7 +127,7 @@ daemonize = no
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = nobody
+;user = nobody
 ;group = nobody
 
 ; The address on which to accept FastCGI requests.


### PR DESCRIPTION
Fixes #59