### PR TITLE
Define start_servers to avoid warning when php-fpm is starting

### DIFF
--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -201,7 +201,7 @@ pm.max_children = ${WEB_CONCURRENCY}
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
 ; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
-;pm.start_servers = 2
+pm.start_servers = 1
 
 ; The desired minimum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'


### PR DESCRIPTION
Fixes #58