### PR TITLE
Add support for extension Phalcon

### DIFF
--- a/support/ext/phalcon
+++ b/support/ext/phalcon
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+phalcon_version="3.4.3"
+
+curl -L "https://github.com/phalcon/cphalcon/archive/v${phalcon_version}.tar.gz" | tar -xzv
+
+cd cphalcon-${phalcon_version}/build
+
+export PATH=$PATH:/app/vendor/php/bin
+
+./install
+
+cp php7/64bits/modules/phalcon.so "$EXT_DIR/phalcon.so"
+echo "extension=phalcon.so" > "$PREFIX/etc/conf.d/phalcon.ini"
+


### PR DESCRIPTION
Version 3.4.3 is deployed

Available for PHP 7.0, 7.1, 7.2, 7.3

https://github.com/phalcon/cphalcon
https://phalconphp.com/en/

To install it:

```
{
  "require": {
    "ext-phalcon": "*"
  }
}
```