### PR TITLE
After supporting phalcon module, support phalcon framework

### DIFF
--- a/conf/nginx/phalcon.conf.erb
+++ b/conf/nginx/phalcon.conf.erb
@@ -1,0 +1,40 @@
+# Inspired from https://docs.phalconphp.com/3.4/en/webserver-setup#nginx
+
+<% if ENV.has_key? "DOCUMENT_ROOT" and ENV['DOCUMENT_ROOT'].to_s != "" %>
+root /app/<%= ENV['DOCUMENT_ROOT'] %>;
+<% else %>
+root /app/public;
+<% end %>
+
+location / {
+    try_files $uri $uri/ /index.php?_url=$uri&$args;
+}
+
+location @rewriteapp {
+    # rewrite all to app.php
+    rewrite ^(.*)$ /index.php/$1 last;
+}
+
+location ~ [^/]\.php(/|$) {
+    fastcgi_pass php;
+    fastcgi_split_path_info ^((?U).+\.php)(/.*)$;
+    include fastcgi_params;
+
+    fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+    fastcgi_buffer_size 128k;
+    fastcgi_buffers 4 256k;
+    fastcgi_busy_buffers_size 256k;
+}
+
+
+location ~ /\.ht {
+    deny all;
+}
+
+location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+    expires       max;
+    log_not_found off;
+    access_log    off;
+}

--- a/frameworks/phalcon
+++ b/frameworks/phalcon
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+BUILD_DIR="$2"
+basedir="$( cd -P "$( dirname "$0" )" && pwd )"
+
+function requires_phalcon() {
+    jq --raw-output '.platform["ext-phalcon"]' < "$BUILD_DIR/composer.lock" | grep -q '^*$'
+}
+
+function sets_framework_phalcon() {
+    [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "phalcon" ]
+}
+
+case "$1" in
+    detect)
+        if [ ! -f "$BUILD_DIR/composer.lock" ]; then
+            exit 1
+        fi
+
+        if requires_phalcon || sets_framework_phalcon; then
+            echo "-----> Detected Phalcon app"
+            exit 0
+        else
+            exit 1
+        fi
+        ;;
+    compile)
+        echo "-----> Setting up Phalcon app"
+        cp "$basedir/../conf/nginx/phalcon.conf.erb" "$BUILD_DIR/conf/site.conf.erb"
+        ;;
+esac


### PR DESCRIPTION
https://sample-php-phalcon.scalingo.io

```
└> git push scalingo master
Enumerating objects: 27, done.
Counting objects: 100% (27/27), done.
Delta compression using up to 4 threads
Compressing objects: 100% (25/25), done.
Writing objects: 100% (27/27), 485.03 KiB | 3.88 MiB/s, done.
Total 27 (delta 0), reused 0 (delta 0)
 <-- Start deployment of sample-php-phalcon -->
       Fetching source code
-----> Cloning custom buildpack: https://github.com/Scalingo/php-buildpack#feature/phalcon-framework
-----> Bundling NGINX 1.15.8
-----> Bundling PHP 7.2.15
-----> Bundling extensions
       apcu
       phpredis
       mongodb
       mcrypt
-----> Vendoring Composer
       Updating Composer
-----> Bundling additional extensions phalcon
       phalcon
Updating to version 1.8.4 (stable channel).
   Downloading (100%)
Use composer self-update --rollback to return to version 1.6.5
-----> Installing application dependencies with Composer
Loading composer repositories with package information
Installing dependencies from lock file
Nothing to install or update
Generating optimized autoload files
-----> Detected Phalcon app
-----> Setting up Phalcon app
-----> Vendoring binaries into slug
 Build complete, shipping your container...
 Waiting for your application to boot... 
 <-- https://sample-php-phalcon.scalingo.io -->
```