### PR TITLE
Update to memcached 3.1.3

### DIFF
--- a/support/ext/memcached
+++ b/support/ext/memcached
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-php_memcached_version=3.0.4
+php_memcached_version=3.1.3
 
 curl -L "https://github.com/php-memcached-dev/php-memcached/archive/v${php_memcached_version}.tar.gz" \
     | tar xzv


### PR DESCRIPTION
This version is mandatory for the support of PHP 7.3.

What needs to be done to update memcached version? Anything else than this
modification?