### PR TITLE
Compatibility with scalingo-18

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "support/php-build"]
-	path = support/php-build
-	url = git://github.com/CHH/php-build

--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -1,6 +1,7 @@
 # Change this to your S3 Bucket if you have custom binaries
+export STACK="${STACK:-scalingo}"
 export SWIFT_BUCKET=scalingo-php-buildpack
-export SWIFT_URL=https://storage.sbg1.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a419eac98613f2/${SWIFT_BUCKET}
+export SWIFT_URL=https://storage.sbg1.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a419eac98613f2/${SWIFT_BUCKET}/${STACK}
 
 # Uncomment if you want debug output and set -x
 # BUILDPACK_DEBUG=yes
@@ -18,7 +19,7 @@ PHP_MODULE_API_VERSIONS["7.3"]="20180731"
 
 memcached_version="1.0.18"
 mcrypt_version="2.5.8"
-zip_version="1.5.1"
+zip_version="1.5.2"
 gmp_version="6.1.2"
 tidy_version="5.6.0"
 coreutils_version="8.30"

--- a/support/get_zip
+++ b/support/get_zip
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-which cmake3 2>/dev/null || (apt-get update && apt-get install -y cmake3)
+package=cmake
+if [ "$STACK" = "scalingo" ] ; then
+  package="cmake3"
+fi
+
+which $package 2>/dev/null || (apt-get update && apt-get install -y $package)
 
 zip_version="$1"
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"

--- a/support/lib/swift
+++ b/support/lib/swift
@@ -2,16 +2,11 @@ function swift_upload() {
   file="$1"
   dest="$2"
 
-  # Require swift client > 1.0
-  # if [ "x$dest" != "x" ] ; then
-  #   opts="--object-name $dest"   
-  # fi
-
-  swift --verbose ${opts} upload ${SWIFT_BUCKET} "${file}"
-  swift --verbose post -r '.r:*' ${SWIFT_BUCKET} "${file}"
+  swift --verbose ${opts} upload ${SWIFT_BUCKET} --object-name "${STACK}/${file}" "${file}"
+  swift --verbose post -r '.r:*' ${SWIFT_BUCKET} "${STACK}/${file}"
 }
 
 function swift_download() {
   file="$1"
-  swift --verbose download ${SWIFT_BUCKET} "${file}"
+  swift --verbose download ${SWIFT_BUCKET} "${STACK}/${file}"
 }

--- a/support/manifest
+++ b/support/manifest
@@ -32,7 +32,7 @@ pushd $tempdir > /dev/null
 echo "-----> Manifest for $manifest_type"
 
 swift list ${SWIFT_BUCKET} \
-    | sed "s/^package\///" \
+    | sed "s/^$STACK\/package\///" \
     | grep "\.tgz$" \
     | grep "^${manifest_type}" \
     | grep -v -e ".md5" \

--- a/support/package-checksum
+++ b/support/package-checksum
@@ -17,5 +17,8 @@ echo "-----> Creating checksum for ${package}"
 
 swift_download "package/${package}.tgz"
 
+[ -d "./package" ] && rm -r ./package
+mv "${STACK}/package" "package"
+
 md5 "package/${package}.tgz" > "package/${package}.md5"
 swift_upload "package/${package}.md5"

--- a/support/package_composer
+++ b/support/package_composer
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+which jq 2>/dev/null || (apt-get update && apt-get install -y jq) 
+
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source "$basedir/../conf/buildpack.conf"
 source "$basedir/lib/utils"

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -19,7 +19,7 @@ if [ -z "$nginx_version" ]; then
 fi
 
 if [ -z "$NGINX_ZLIB_VERSION" ]; then
-    NGINX_ZLIB_VERSION=1.2.8
+    NGINX_ZLIB_VERSION=1.2.11
 fi
 
 if [ -z "$NGINX_PCRE_VERSION" ]; then

--- a/support/package_php
+++ b/support/package_php
@@ -18,7 +18,7 @@ php_version="$1"
 mcrypt_version="2.5.8"
 
 if [ -z "$PHP_ZLIB_VERSION" ]; then
-    PHP_ZLIB_VERSION=1.2.8
+    PHP_ZLIB_VERSION=1.2.11
 fi
 
 echo "-----> Packaging PHP $php_version"
@@ -30,10 +30,16 @@ echo "-----> Downloading dependency zlib ${PHP_ZLIB_VERSION}"
 curl -LO "${SWIFT_URL}/zlib/zlib-${PHP_ZLIB_VERSION}.tar.gz"
 tar -xzvf "zlib-${PHP_ZLIB_VERSION}.tar.gz"
 
-echo "-----> Downloading dependency libzip ${zip_version}"
-mkdir /app/vendor/libzip -p
-curl -L -o - "${SWIFT_URL}/package/libzip-${zip_version}.tgz" | tar -C /app/vendor/libzip -xvz
-export C_INCLUDE_PATH="$C_INCLUDE_PATH:/app/vendor/libzip/include"
+# If we're using the stack scalingo
+# - it requires a custom libzip
+libzip_flag=""
+if [ "$STACK" = "scalingo" ] ; then
+  echo "-----> Downloading dependency libzip ${zip_version}"
+  mkdir /app/vendor/libzip -p
+  curl -L -o - "${SWIFT_URL}/package/libzip-${zip_version}.tgz" | tar -C /app/vendor/libzip -xvz
+  export C_INCLUDE_PATH="$C_INCLUDE_PATH:/app/vendor/libzip/include"
+  libzip_flag="--with-libzip=/app/vendor/libzip"
+fi
 
 echo "-----> Downloading PHP $php_version"
 curl -LO "http://php.net/distributions/php-${php_version}.tar.gz"
@@ -78,7 +84,7 @@ mkdir -p "/app/vendor/php/zlib" "/app/vendor/libmcrypt" \
 --enable-shmop \
 --enable-zip \
 ${WITH_CURL_CONFIGURE} \
---with-libzip=/app/vendor/libzip \
+${libzip_flag} \
 --with-jpeg-dir=/usr \
 --with-png-dir=/usr \
 --with-freetype-dir=/usr \


### PR DESCRIPTION
Of course, retrocompatible with scalingo, assets of the legacy stack have been migrated, to the `scalingo/` namespace on the object storage