### PR TITLE
Fix output for additional extensions

### DIFF
--- a/lib/composer
+++ b/lib/composer
@@ -57,7 +57,7 @@ function install_composer_deps() {
 
     local required_extensions=$(jq --raw-output '.require // {} | keys | .[]' < "$BUILD_DIR/composer.json" | grep '^ext-' | sed 's/^ext-//')
     if [ -n "$required_extensions" ]; then
-        status "Bundling additional extensions $required_extensions"
+        status "Bundling additional extensions"
         for ext in $required_extensions; do
             echo "$ext" | indent
             # TODO: Find a better way to ignore extensions which were not found in S3

--- a/support/lib/output
+++ b/support/lib/output
@@ -1,7 +1,10 @@
+# sed -l basically makes sed replace and buffer through stdin to stdout
+# so you get updates while the command runs and dont wait for the end
+# e.g. npm install | indent
 indent() {
-    c='s/^/       /'
-    case $(uname) in
-        Darwin) sed -l "$c";;
-        *)      sed -u "$c";;
-    esac
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
+    *)      sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+  esac
 }

--- a/support/manifest
+++ b/support/manifest
@@ -7,14 +7,15 @@ if [ -z "$manifest_type" ]; then
     exit 1
 fi
 
+# sed -l basically makes sed replace and buffer through stdin to stdout
+# so you get updates while the command runs and dont wait for the end
+# e.g. npm install | indent
 indent() {
-    local expr='s/^/       /'
-
-    if [ $(uname -s) = "Darwin" ]; then
-        sed -l "$expr"
-    else
-        sed -u "$expr"
-    fi
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";; # mac/bsd sed: -l buffers on line boundaries
+    *)      sed -u "$c";; # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
+  esac
 }
 
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"


### PR DESCRIPTION
Close #111 

Preview:
```bash
 <-- Start deployment of php-buildpack-test -->
       Fetching source code
       Fetching deployment cache
-----> Cloning custom buildpack: https://github.com/Scalingo/php-buildpack#fix/111/output-enhancement
-----> Bundling NGINX 1.15.8
       Checksums match. Fetching from cache.
-----> Bundling PHP 7.4.0
       Checksums match. Fetching from cache.
-----> Bundling extensions
       apcu
       Checksums match. Fetching from cache.
       phpredis
       Checksums match. Fetching from cache.
       mongodb
       Checksums match. Fetching from cache.
-----> Vendoring Composer
-----> Bundling additional extensions: curl json libxml mbstring openssl simplexml 
       curl
       Checksums match. Fetching from cache.
       json
       Checksums match. Fetching from cache.
       libxml
       Checksums match. Fetching from cache.
       mbstring
       Checksums match. Fetching from cache.
       openssl
       Checksums match. Fetching from cache.
       simplexml
       Checksums match. Fetching from cache.
Updating to version 1.9.1 (stable channel).
   Downloading (100%)
Use composer self-update --rollback to return to version 1.8.5
-----> Installing application dependencies with Composer
Loading composer repositories with package information
Installing dependencies from lock file
Nothing to install or update
Generating optimized autoload files
-----> Setting up default configuration
-----> Vendoring binaries into slug
 Build complete, shipping your container...
 Waiting for your application to boot... 
 <-- https://php-buildpack-test.osc-fr1.scalingo.io -->
```

@EtienneM It is good for you?