### PR TITLE
Nginx and PHP versions from semver

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -156,7 +156,7 @@ export PATH="$BUILD_DIR/bin:$PATH"
 curl --fail "${SWIFT_URL}/jq/jq" -L -s -o - > "$BUILD_DIR/bin/jq"
 chmod +x "$BUILD_DIR/bin/jq"
 
-DEFAULT_PHP="7.3"
+DEFAULT_PHP=$(curl --fail --location --silent "${SEMVER_SERVER}/php-${STACK}")
 DEFAULT_NGINX="1.15.8"
 
 AVAILABLE_NGINX_VERSIONS=$(curl "${SWIFT_URL}/manifest.nginx" 2> /dev/null)

--- a/bin/compile
+++ b/bin/compile
@@ -157,7 +157,7 @@ curl --fail "${SWIFT_URL}/jq/jq" -L -s -o - > "$BUILD_DIR/bin/jq"
 chmod +x "$BUILD_DIR/bin/jq"
 
 DEFAULT_PHP=$(curl --fail --location --silent "${SEMVER_SERVER}/php-${STACK}")
-DEFAULT_NGINX="1.15.8"
+DEFAULT_NGINX=$(curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}")
 
 AVAILABLE_NGINX_VERSIONS=$(curl "${SWIFT_URL}/manifest.nginx" 2> /dev/null)
 


### PR DESCRIPTION
The default Nginx with the current buildpack is `1.15.8` as reported by the user in the related issue. With this version of the buildpack:

```
 <-- Start deployment of etienne-default-nginx -->
       Fetching source code
-----> Cloning custom buildpack: https://github.com/Scalingo/php-buildpack.git#fix/120/default_nginx
-----> Bundling NGINX 1.16.1
-----> Bundling PHP 7.4.1
[...]
```

1.16.1 is the default returned by semver (http://semver.scalingo.io/nginx-scalingo-18/). ~I need to find how to configure semver to return 1.17.6 as the new default.~ Actually 1.16.1 is the latest on the stable branch. It's probably best to use it as default, don't you think? 

With an unsupported version of Nginx:

```
 <-- Start deployment of etienne-default-nginx -->
       Fetching source code
       Fetching deployment cache
-----> Cloning custom buildpack: https://github.com/Scalingo/php-buildpack.git#fix/120/default_nginx
 !     Nginx version 7.4 is not supported.
 !     Supported versions are: 1.17.6 1.17.5 1.17.4 1.17.3 1.17.2 1.17.1 1.17.0 1.16.1 1.16.0 1.15.8 1.14.2
 !     An error occured during buildpack compilation
```

Related to #120