### PR TITLE
Make the Composer version configurable

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -77,7 +77,7 @@ function best_composer_version() {
   if [ -f "$BUILD_DIR/composer.json" ] ; then
     require_composer=$(jq --raw-output ".extra.${composer_extra_key}.engines.composer // \"\"" < "$BUILD_DIR/composer.json")
   fi
-  if [ -n "COMPOSER_VERSION" ] ; then
+  if [ -n "$COMPOSER_VERSION" ] ; then
     require_composer="$COMPOSER_VERSION"
   fi
   [ -z "${require_composer}" ] && require_composer="$DEFAULT_COMPOSER"
@@ -95,7 +95,7 @@ function best_nginx_version() {
       [ -n "${require_nginx}" ] && break
     done
   fi
-  if [ -n "NGINX_VERSION" ] ; then
+  if [ -n "$NGINX_VERSION" ] ; then
     require_nginx="$NGINX_VERSION"
   fi
   [ -z "${require_nginx}" ] && require_nginx="$DEFAULT_NGINX"

--- a/bin/compile
+++ b/bin/compile
@@ -207,7 +207,7 @@ fi
 
 PHP_VERSION=$(best_php_version)
 NGINX_VERSION=$(best_nginx_version)
-export COMPOSER_VERSION=$(best_composer_version)
+COMPOSER_VERSION=$(best_composer_version)
 DOCUMENT_ROOT="${DOCUMENT_ROOT:-}"
 INDEX_DOCUMENT="${INDEX_DOCUMENT:-index.php}"
 FRAMEWORK="${FRAMEWORK:-}"

--- a/bin/compile
+++ b/bin/compile
@@ -90,6 +90,10 @@ function best_nginx_version() {
   local require_nginx=""
   if [ -f "$BUILD_DIR/composer.json" ] ; then
     require_nginx=$(jq --raw-output ".require.nginx // \"\"" < "$BUILD_DIR/composer.json")
+    for key in ".require.nginx" ".extra.${composer_extra_key}.engines.nginx" ; do
+      require_nginx=$(jq --raw-output "${key} // \"\"" < "$BUILD_DIR/composer.json")
+      [ -n "${require_nginx}" ] && break
+    done
   fi
   if [ -n "NGINX_VERSION" ] ; then
     require_nginx="$NGINX_VERSION"

--- a/bin/compile
+++ b/bin/compile
@@ -217,6 +217,16 @@ ACCESS_LOG_FORMAT_COMPOSER_JSON="${ACCESS_LOG_FORMAT_COMPOSER_JSON:-}"
 NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.9.0.260}"
 LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
 
+# Display a warning that Composer version 1.x is End of Life
+if [[ "$COMPOSER_VERSION" = 1.* ]]; then
+  echo >&2 ""
+  echo >&2 "######################################"
+  echo >&2 "WARNING: You are using Composer ${COMPOSER_VERSION}. Composer 1 is End of Life since the 24th of October 2020 and will soon be deprecated."
+  echo >&2 "https://doc.scalingo.com/languages/php/start#select-a-composer-version"
+  echo >&2 "######################################"
+  echo >&2 ""
+fi
+
 check_composer_syntax "$BUILD_DIR"
 check_composer_json_and_lock "$BUILD_DIR"
 

--- a/bin/compile
+++ b/bin/compile
@@ -72,6 +72,20 @@ function detect_framework() {
   done
 }
 
+function best_composer_version() {
+  local require_composer=""
+  if [ -f "$BUILD_DIR/composer.json" ] ; then
+    require_composer=$(jq --raw-output ".extra.${composer_extra_key}.engines.composer // \"\"" < "$BUILD_DIR/composer.json")
+  fi
+  if [ -n "COMPOSER_VERSION" ] ; then
+    require_composer="$COMPOSER_VERSION"
+  fi
+  [ -z "${require_composer}" ] && require_composer="$DEFAULT_COMPOSER"
+  # TODO when semver is updated:
+  # curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}/resolve/${require_nginx}"
+  echo $require_composer
+}
+
 function best_nginx_version() {
   local require_nginx=""
   if [ -f "$BUILD_DIR/composer.json" ] ; then
@@ -175,6 +189,8 @@ chmod +x "$BUILD_DIR/bin/jq"
 
 DEFAULT_PHP=$(curl --fail --location --silent "${SEMVER_SERVER}/php-${STACK}")
 DEFAULT_NGINX=$(curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}")
+# TODO: Update semver to add support for Composer
+DEFAULT_COMPOSER=2.0.2
 
 # Read config variables from composer.json if it exists
 if [ -f "$BUILD_DIR/composer.json" ]; then
@@ -187,6 +203,7 @@ fi
 
 PHP_VERSION=$(best_php_version)
 NGINX_VERSION=$(best_nginx_version)
+COMPOSER_VERSION=$(best_composer_version)
 DOCUMENT_ROOT="${DOCUMENT_ROOT:-}"
 INDEX_DOCUMENT="${INDEX_DOCUMENT:-index.php}"
 FRAMEWORK="${FRAMEWORK:-}"

--- a/bin/compile
+++ b/bin/compile
@@ -87,7 +87,6 @@ function best_composer_version() {
 function best_nginx_version() {
   local require_nginx=""
   if [ -f "$BUILD_DIR/composer.json" ] ; then
-    require_nginx=$(jq --raw-output ".require.nginx // \"\"" < "$BUILD_DIR/composer.json")
     for key in ".require.nginx" ".extra.${composer_extra_key}.engines.nginx" ; do
       require_nginx=$(jq --raw-output "${key} // \"\"" < "$BUILD_DIR/composer.json")
       [ -n "${require_nginx}" ] && break

--- a/bin/compile
+++ b/bin/compile
@@ -81,9 +81,7 @@ function best_composer_version() {
     require_composer="$COMPOSER_VERSION"
   fi
   [ -z "${require_composer}" ] && require_composer="$DEFAULT_COMPOSER"
-  # TODO when semver is updated:
-  # curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}/resolve/${require_nginx}"
-  echo $require_composer
+  curl --fail --location --silent "${SEMVER_SERVER}/composer-${STACK}/resolve/${require_composer}"
 }
 
 function best_nginx_version() {
@@ -193,8 +191,7 @@ chmod +x "$BUILD_DIR/bin/jq"
 
 DEFAULT_PHP=$(curl --fail --location --silent "${SEMVER_SERVER}/php-${STACK}")
 DEFAULT_NGINX=$(curl --fail --location --silent "${SEMVER_SERVER}/nginx-${STACK}")
-# TODO: Update semver to add support for Composer
-DEFAULT_COMPOSER=2.0.2
+DEFAULT_COMPOSER=$(curl --fail --location --silent "${SEMVER_SERVER}/composer-${STACK}")
 
 # Read config variables from composer.json if it exists
 if [ -f "$BUILD_DIR/composer.json" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -244,7 +244,7 @@ VENDORED_PHP=/app/vendor/php
 
 [ ! -d "$BUILD_DIR/vendor" ] && mkdir -p "$BUILD_DIR/vendor"
 
-status "Bundling NGINX ${NGINX_VERSION}"
+status "Bundling Nginx ${NGINX_VERSION}"
 fetch_engine_package nginx "$NGINX_VERSION" "${VENDORED_NGINX}" | indent
 
 status "Bundling PHP ${PHP_VERSION}"

--- a/bin/compile
+++ b/bin/compile
@@ -207,7 +207,7 @@ fi
 
 PHP_VERSION=$(best_php_version)
 NGINX_VERSION=$(best_nginx_version)
-COMPOSER_VERSION=$(best_composer_version)
+export COMPOSER_VERSION=$(best_composer_version)
 DOCUMENT_ROOT="${DOCUMENT_ROOT:-}"
 INDEX_DOCUMENT="${INDEX_DOCUMENT:-index.php}"
 FRAMEWORK="${FRAMEWORK:-}"

--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -6,7 +6,7 @@ export SWIFT_URL=https://storage.sbg.cloud.ovh.net/v1/AUTH_be65d32d71a6435589a41
 # Uncomment if you want debug output and set -x
 # BUILDPACK_DEBUG=yes
 
-SEMVER_SERVER="https://semver.scalingo.io"
+SEMVER_SERVER="https://semver.scalingo.com"
 
 declare -A PHP_MODULE_API_VERSIONS
 PHP_MODULE_API_VERSIONS["5.4"]="20100525"

--- a/frameworks/phalcon
+++ b/frameworks/phalcon
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 BUILD_DIR="$2"
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 

--- a/frameworks/phalcon
+++ b/frameworks/phalcon
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 BUILD_DIR="$2"
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 

--- a/frameworks/phalcon
+++ b/frameworks/phalcon
@@ -6,7 +6,7 @@ BUILD_DIR="$2"
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 
 function requires_phalcon() {
-    jq --raw-output '.platform["ext-phalcon"]' < "$BUILD_DIR/composer.lock" | grep -q '^*$'
+    jq --raw-output '.platform' < "$BUILD_DIR/composer.lock" | grep -q 'ext-phalcon'
 }
 
 function sets_framework_phalcon() {

--- a/lib/composer
+++ b/lib/composer
@@ -1,3 +1,5 @@
+# vim:set ft=sh:
+
 function check_composer_syntax() {
   local target="$1"
 

--- a/lib/composer
+++ b/lib/composer
@@ -83,9 +83,9 @@ function install_composer_deps() {
 
     status "Installing application dependencies with Composer"
     {
-	local devopt="--no-dev"
-	local dev=${COMPOSER_DEV:=false}
-	[ "x$dev" = "xtrue" ] && devopt="--dev"
+        local devopt="--no-dev"
+        local dev=${COMPOSER_DEV:=false}
+        [ "x$dev" = "xtrue" ] && devopt="--dev"
 
         cd "$target"
         php "vendor/composer/bin/composer.phar" install \

--- a/lib/composer
+++ b/lib/composer
@@ -41,12 +41,12 @@ function install_composer_deps() {
     mkdir -p $COMPOSER_CACHE_DIR
     mkdir -p "$target/vendor/composer/bin"
 
-    local checksum=$(curl --silent "${SWIFT_URL}/composer/composer.phar.md5")
+    local checksum=$(curl --silent "${SWIFT_URL}/composer/composer-${COMPOSER_VERSION}.phar.md5")
 
-    status "Vendoring Composer"
+    status "Vendoring Composer ${COMPOSER_VERSION}"
     if [ ! -f "$CACHE_DIR/composer.phar.md5" ] || [ "$(cat $CACHE_DIR/composer.phar.md5)" != "$checksum" ]; then
         echo "Updating Composer" | indent
-        curl --silent "${SWIFT_URL}/composer/composer.phar" > "$CACHE_DIR/composer.phar" | indent
+        curl --silent "${SWIFT_URL}/composer/composer-${COMPOSER_VERSION}.phar" > "$CACHE_DIR/composer.phar" | indent
         chmod a+x "$CACHE_DIR/composer.phar"
         echo "$checksum" > $CACHE_DIR/composer.phar.md5
     fi
@@ -73,8 +73,6 @@ function install_composer_deps() {
             fetch_package "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
         done
     fi
-
-    php "vendor/composer/bin/composer.phar" self-update
 
     if [ -n "$COMPOSER_GITHUB_TOKEN" ]; then
         status "Configuring the github authentication for Composer"

--- a/lib/composer
+++ b/lib/composer
@@ -49,6 +49,8 @@ function install_composer_deps() {
         curl --silent "${SWIFT_URL}/composer/composer-${COMPOSER_VERSION}.phar" > "$CACHE_DIR/composer.phar" | indent
         chmod a+x "$CACHE_DIR/composer.phar"
         echo "$checksum" > $CACHE_DIR/composer.phar.md5
+    else
+        echo "Checksums match. Fetching from cache."
     fi
 
     cp "$CACHE_DIR/composer.phar" "$target/vendor/composer/bin/"

--- a/support/lib/swift
+++ b/support/lib/swift
@@ -1,3 +1,5 @@
+# vim:set ft=sh:
+
 function swift_upload() {
   file="$1"
 

--- a/support/package_composer
+++ b/support/package_composer
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-which jq 2>/dev/null || (apt-get update && apt-get install -y jq) 
+set -e
+
+composer_version="$1"
+
+which jq 2>/dev/null || (apt-get update && apt-get install -y jq)
 
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source "$basedir/../conf/buildpack.conf"
@@ -10,16 +14,41 @@ source "$basedir/lib/swift"
 tempdir=$(mktmpdir composer)
 cd $tempdir
 
-BASE_COMPOSER_URL="https://getcomposer.org/"
+BASE_COMPOSER_URL="https://getcomposer.org"
 
-current_composer_version_path=$(curl --silent "$BASE_COMPOSER_URL/versions" | jq -r '.stable[0].path')
+if [ -z "$composer_version" ]; then
+  composer_version=$(curl --silent "$BASE_COMPOSER_URL/versions" | jq -r '.stable[0].version')
+  current_composer_version_path=$(curl --silent "$BASE_COMPOSER_URL/versions" | jq -r '.stable[0].path')
+  echo "Composer version not specified, packaging the last stable version ($composer_version)"
+else
+  echo "Packaging Composer version $composer_version"
+  current_composer_version_path="/download/${composer_version}/composer.phar"
+fi
 
-curl -L "$BASE_COMPOSER_URL/$current_composer_version_path" > composer.phar
-md5 composer.phar > composer.phar.md5
+curl -L "$BASE_COMPOSER_URL/$current_composer_version_path" > composer-${composer_version}.phar
+md5 composer-${composer_version}.phar > composer-${composer_version}.phar.md5
+
+echo "-----> Uploading Composer package to Swift ${SWIFT_URL}/composer/composer-${composer_version}.phar"
 
 mkdir composer
-mv composer.phar composer
-mv composer.phar.md5 composer
+mv composer-${composer_version}.phar composer
+mv composer-${composer_version}.phar.md5 composer
 
-swift_upload "composer/composer.phar"
-swift_upload "composer/composer.phar.md5"
+swift_upload "composer/composer-${composer_version}.phar"
+swift_upload "composer/composer-${composer_version}.phar.md5"
+
+# This manifest file is important for Semver to know which Composer versions are available
+echo "-----> Manifest for composer"
+swift list scalingo-php-buildpack | grep $STACK \
+  | cut -d "/" -f 3 \
+  | grep "^composer-" | grep "\.phar$" \
+  | sed -e "s/composer-\([0-9.]*\)\\.phar/\\1/" \
+  | awk 'BEGIN {FS="."} {printf("%03d.%03d.%03d %s\n",$1,$2,$3,$0)}' \
+  | sort -r | cut -d" " -f2 \
+  > manifest.composer
+
+echo
+echo "-----> Uploading manifest for composer to Swift"
+swift_upload manifest.composer
+
+echo "-----> Done building Composer package!"

--- a/support/package_nginx
+++ b/support/package_nginx
@@ -66,7 +66,7 @@ pushd nginx-${nginx_version} >/dev/null && \
   make && make install && \
   popd > /dev/null
 
-echo "-----> Uploading package to Swift https://${SWIFT_URL}/${STACK}/package/nginx-${nginx_version}.tgz"
+echo "-----> Uploading package to Swift ${SWIFT_URL}/package/nginx-${nginx_version}.tgz"
 
 mkdir package
 pushd /app/vendor/nginx >/dev/null


### PR DESCRIPTION
Example of warning message:

```
╰─$ git push scalingo master --force
[...]
Your deployment has been queued and is going to start…
 <-- Start deployment of test-php-buildpack -->
       Fetching source code
       Fetching deployment cache
-----> Cloning custom buildpack: https://github.com/Scalingo/php-buildpack#fix/168/composer_version_configurable
######################################
WARNING: You are using Composer 1.10.16. Composer 1 is End of Life since the 24th of October 2020 and will soon be deprecated.
https://blog.packagist.com/composer-2-0-is-now-available/#4-what-s-next
######################################
-----> Bundling Nginx 1.18.0
[...]
-----> Vendoring Composer 1.10.16
       Updating Composer
[...]
```

See the latest deployments of https://my.osc-fr1.scalingo.com/apps/test-php-buildpack/deployments

Fix #168