### PR TITLE
Ensure new relic logs are working all the time, not only when starting php-fpm (web containers)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -422,10 +422,19 @@ export NGINX_INCLUDES="\${NGINX_INCLUDES:-$NGINX_INCLUDES}"
 export ACCESS_LOG_FORMAT_COMPOSER_JSON='$ACCESS_LOG_FORMAT_COMPOSER_JSON'
 export ACCESS_LOG_FORMAT="\${ACCESS_LOG_FORMAT:-\$ACCESS_LOG_FORMAT_COMPOSER_JSON}"
 
-if [ -n "\$NEW_RELIC_LICENSE_KEY" ]; then
+if [ -f "\$/app/vendor/php/etc/conf.d/newrelic.ini" ] ; then
     export NEW_RELIC_LOG_DAEMON=\${NEW_RELIC_LOG_DAEMON:=/app/vendor/newrelic/daemon.log}
     export NEW_RELIC_LOG_AGENT=\${NEW_RELIC_LOG_AGENT:=/app/vendor/newrelic/agent.log}
-    echo "newrelic.license=\"\$NEW_RELIC_LICENSE_KEY\"" > /app/vendor/php/etc/conf.d/newrelic_license.ini
+    if [ -n "\$NEW_RELIC_LICENSE_KEY" ]; then
+        echo "newrelic.license=\"\$NEW_RELIC_LICENSE_KEY\"" > /app/vendor/php/etc/conf.d/newrelic_license.ini
+    else
+        echo " !"
+        echo " ! New Relic agent has been installed but is misconfigured"
+        echo " ! NEW_RELIC_LICENSE_KEY should be define in the application environment"
+        echo " !"
+        echo " ! Documentation: https://doc.scalingo.com/languages/php/start"
+        echo " !"
+    fi
 fi
 
 erb conf/nginx.conf.erb > /app/vendor/nginx/conf/nginx.conf

--- a/bin/compile
+++ b/bin/compile
@@ -280,6 +280,9 @@ fi
 if [ -f "$BUILD_DIR/composer.json" ] && package_newrelic_enabled; then
     LOG_FILES+=( "/app/vendor/newrelic/daemon.log" "/app/vendor/newrelic/agent.log" )
     install_newrelic "$NEWRELIC_VERSION"
+
+    echo 'export NEW_RELIC_LOG_DAEMON=${NEW_RELIC_LOG_DAEMON:=/app/vendor/newrelic/daemon.log}' >> ".profile.d/php.sh"
+    echo 'export NEW_RELIC_LOG_AGENT=${NEW_RELIC_LOG_AGENT:=/app/vendor/newrelic/agent.log}' >> ".profile.d/php.sh"
 fi
 
 if [ -n "$BLACKFIRE_SERVER_ID" -a -n "$BLACKFIRE_SERVER_TOKEN" ] ; then
@@ -423,8 +426,6 @@ export ACCESS_LOG_FORMAT_COMPOSER_JSON='$ACCESS_LOG_FORMAT_COMPOSER_JSON'
 export ACCESS_LOG_FORMAT="\${ACCESS_LOG_FORMAT:-\$ACCESS_LOG_FORMAT_COMPOSER_JSON}"
 
 if [ -f "\$/app/vendor/php/etc/conf.d/newrelic.ini" ] ; then
-    export NEW_RELIC_LOG_DAEMON=\${NEW_RELIC_LOG_DAEMON:=/app/vendor/newrelic/daemon.log}
-    export NEW_RELIC_LOG_AGENT=\${NEW_RELIC_LOG_AGENT:=/app/vendor/newrelic/agent.log}
     if [ -n "\$NEW_RELIC_LICENSE_KEY" ]; then
         echo "newrelic.license=\"\$NEW_RELIC_LICENSE_KEY\"" > /app/vendor/php/etc/conf.d/newrelic_license.ini
     else

--- a/bin/compile
+++ b/bin/compile
@@ -425,7 +425,7 @@ export NGINX_INCLUDES="\${NGINX_INCLUDES:-$NGINX_INCLUDES}"
 export ACCESS_LOG_FORMAT_COMPOSER_JSON='$ACCESS_LOG_FORMAT_COMPOSER_JSON'
 export ACCESS_LOG_FORMAT="\${ACCESS_LOG_FORMAT:-\$ACCESS_LOG_FORMAT_COMPOSER_JSON}"
 
-if [ -f "\$/app/vendor/php/etc/conf.d/newrelic.ini" ] ; then
+if [ -f "/app/vendor/php/etc/conf.d/newrelic.ini" ] ; then
     if [ -n "\$NEW_RELIC_LICENSE_KEY" ]; then
         echo "newrelic.license=\"\$NEW_RELIC_LICENSE_KEY\"" > /app/vendor/php/etc/conf.d/newrelic_license.ini
     else


### PR DESCRIPTION
Warning if license key is missing

```
2020-11-05 10:07:05.032877300 +0100 CET [manager] container [web-1] (5fa3c0aa987e0b2c03995458) started
2020-11-05 10:07:05.133446753 +0100 CET [web-1] !
2020-11-05 10:07:05.133474240 +0100 CET [web-1] ! New Relic agent has been installed but is misconfigured
2020-11-05 10:07:05.133486005 +0100 CET [web-1] ! NEW_RELIC_LICENSE_KEY should be define in the application environment
2020-11-05 10:07:05.133490749 +0100 CET [web-1] !
2020-11-05 10:07:05.133491857 +0100 CET [web-1] ! Documentation: https://doc.scalingo.com/languages/php/start
2020-11-05 10:07:05.133492612 +0100 CET [web-1] !
```