### PR TITLE
Correctly handle when composer.json includes: '.extra.paas.framework == ""', no more warning of unary operator

### DIFF
--- a/frameworks/cakephp2
+++ b/frameworks/cakephp2
@@ -5,11 +5,11 @@ basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source $basedir/../bin/common.sh
 
 function requires_cakephp2() {
-    [ $(jq --raw-output '.require["pear-pear.cakephp.org/CakePHP"]' < "$BUILD_DIR/composer.json") != "null" ]
+    [ "$(jq --raw-output '.require["pear-pear.cakephp.org/CakePHP"]' < "$BUILD_DIR/composer.json")" != "null" ]
 }
 
 function sets_framework_cakephp2() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "cakephp2" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "cakephp2" ]
 }
 
 case "$1" in

--- a/frameworks/change4
+++ b/frameworks/change4
@@ -5,7 +5,7 @@ basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source $basedir/../bin/common.sh
 
 function requires_change4() {
-  require_change=$(jq --raw-output ".require[\"rbschange/core\"] // \"\"" < "$BUILD_DIR/composer.json")
+  require_change="$(jq --raw-output ".require[\"rbschange/core\"] // \"\"" < "$BUILD_DIR/composer.json")"
   [ -n  "$require_change" ]
 }
 

--- a/frameworks/drupal
+++ b/frameworks/drupal
@@ -8,7 +8,7 @@ function requires_drupal() {
 }
 
 function sets_framework_drupal() {
-    [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "drupal" ]
+    [ "$(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json")" == "drupal" ]
 }
 
 case "$1" in

--- a/frameworks/laravel
+++ b/frameworks/laravel
@@ -5,7 +5,7 @@ basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source $basedir/../bin/common.sh
 
 function requires_laravel() {
-  require_change=$(jq --raw-output ".require[\"laravel/framework\"] // \"\"" < "$BUILD_DIR/composer.json")
+  require_change="$(jq --raw-output ".require[\"laravel/framework\"] // \"\"" < "$BUILD_DIR/composer.json")"
   [ -n  "$require_change" ]
 }
 

--- a/frameworks/lumen
+++ b/frameworks/lumen
@@ -8,7 +8,7 @@ function requires_lumen() {
 }
 
 function sets_framework_lumen() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "lumen" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "lumen" ]
 }
 
 case "$1" in

--- a/frameworks/phalcon
+++ b/frameworks/phalcon
@@ -8,7 +8,7 @@ function requires_phalcon() {
 }
 
 function sets_framework_phalcon() {
-    [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "phalcon" ]
+    [ "$(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json")" == "phalcon" ]
 }
 
 case "$1" in

--- a/frameworks/prestashop
+++ b/frameworks/prestashop
@@ -9,7 +9,7 @@ function requires_prestashop() {
 }
 
 function sets_framework_prestashop() {
-    [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "prestashop" ]
+    [ "$(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json")" == "prestashop" ]
 }
 
 # PrestaShop is based on Symfony, so it's really closed to symfony logics

--- a/frameworks/silex
+++ b/frameworks/silex
@@ -8,7 +8,7 @@ function requires_silex() {
 }
 
 function sets_framework_silex() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "silex" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "silex" ]
 }
 
 case "$1" in

--- a/frameworks/slim
+++ b/frameworks/slim
@@ -8,7 +8,7 @@ function requires_slim() {
 }
 
 function sets_framework_slim() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "slim" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "slim" ]
 }
 
 case "$1" in

--- a/frameworks/symfony
+++ b/frameworks/symfony
@@ -18,7 +18,7 @@ function requires_symfony_flex() {
 }
 
 function sets_framework_symfony() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "symfony" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "symfony" ]
 }
 
 function is_symfony2() {

--- a/frameworks/yii
+++ b/frameworks/yii
@@ -8,7 +8,7 @@ function requires_yii() {
 }
 
 function sets_framework_yii() {
-    [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "yii" ]
+    [ "$(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json")" == "yii" ]
 }
 
 case "$1" in

--- a/frameworks/yii2
+++ b/frameworks/yii2
@@ -8,7 +8,7 @@ function requires_yii2() {
 }
 
 function sets_framework_yii2() {
-  [ $(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json") == "yii2" ]
+  [ "$(jq --raw-output '.extra.paas.framework' < "$BUILD_DIR/composer.json")" == "yii2" ]
 }
 
 case "$1" in

--- a/frameworks/zf2
+++ b/frameworks/zf2
@@ -8,7 +8,7 @@ function requires_zf2() {
 }
 
 function sets_framework_zf2() {
-    [ $(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json") == "zf2" ]
+    [ "$(jq --raw-output '.extra.heroku.framework' < "$BUILD_DIR/composer.json")" == "zf2" ]
 }
 
 case "$1" in


### PR DESCRIPTION
To fix this I've just used good practice for bash script: always using quotes and interpolating content in it when comparing to string