### PR TITLE
release(new-relic): default version from 9.16.0.295 to 9.17.1.301

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -219,7 +219,8 @@ COMPILE_CMD="${COMPILE_CMD:-}"
 NGINX_HTTP_INCLUDES="${NGINX_HTTP_INCLUDES:-}"
 NGINX_INCLUDES="${NGINX_INCLUDES:-}"
 ACCESS_LOG_FORMAT_COMPOSER_JSON="${ACCESS_LOG_FORMAT_COMPOSER_JSON:-}"
-NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.16.0.295}"
+# Version number comes from https://download.newrelic.com/php_agent/archive/
+NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.17.1.301}"
 LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
 
 # Display a warning that Composer version 1.x is End of Life


### PR DESCRIPTION
Tested in https://dashboard.scalingo.com/apps/osc-fr1/biniou/deploy/db1b2650-e373-47b4-9b26-575c856a0945

Fix #194