### PR TITLE
release(php): add support for PHP 8.1

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -18,6 +18,7 @@ PHP_MODULE_API_VERSIONS["7.2"]="20170718"
 PHP_MODULE_API_VERSIONS["7.3"]="20180731"
 PHP_MODULE_API_VERSIONS["7.4"]="20190902"
 PHP_MODULE_API_VERSIONS["8.0"]="20200930"
+PHP_MODULE_API_VERSIONS["8.1"]="20210902"
 
 # The following lib versions are used for lib we statically store on Swift.
 # They are downloaded, compiled and stored with /support/get_* scripts.

--- a/support/ext-internal/sodium
+++ b/support/ext-internal/sodium
@@ -8,7 +8,7 @@ php_src_dir=$3
 
 source "/buildpack/conf/buildpack.conf"
 if echo "$php_version" | grep -qE "^7.[23]" ; then
-  sodium_version="1.0.7"
+  sodium_version="$sodium_php72_php73_version"
 fi
 
 sodium_package="${SWIFT_URL}/package/libsodium-${sodium_version}.tgz"

--- a/support/ext-internal/sodium
+++ b/support/ext-internal/sodium
@@ -17,7 +17,7 @@ curl -L "$sodium_package" > /tmp/sodium-${sodium_version}.tgz
 
 libsodium_path=/app/vendor/libsodium
 
-rm -r "${libsodium_path}"
+rm -rf "${libsodium_path}"
 mkdir -p "${libsodium_path}"
 tar -xzv -C "${libsodium_path}" -f /tmp/sodium-${sodium_version}.tgz
 

--- a/support/ext/mongodb
+++ b/support/ext/mongodb
@@ -3,7 +3,7 @@
 set -e
 
 # https://github.com/mongodb/mongo-php-driver/releases
-mongo_version="1.10.0"
+mongo_version="1.11.1"
 
 curl -L "https://github.com/mongodb/mongo-php-driver/releases/download/${mongo_version}/mongodb-${mongo_version}.tgz" \
     | tar xzv

--- a/support/package_all
+++ b/support/package_all
@@ -23,6 +23,14 @@ done
 
 for e in ./ext/*; do
   ext_name=$(basename $e)
+  if [[ "$php_version" = "8.1" ]]; then
+    if [[ "$ext_name" = "ds" ]]; then
+      continue
+    fi
+    if [[ "$ext_name" = "lua" ]]; then
+      continue
+    fi
+  fi
   ./package_ext $ext_name $ext_name $php_version
   if [[ $? -ne 0 ]]; then
     echo "Error packaging extension ${ext_name}"

--- a/support/package_php
+++ b/support/package_php
@@ -100,6 +100,13 @@ if [[ "${PHP_MODULE_API_VERSIONS["$php_series"]}" -ge "${PHP_MODULE_API_VERSIONS
   WITH_ARGON_CONFIGURE="--with-password-argon2"
 fi
 
+# As of PHP 8.0 the XML-RPC module has been moved to PECL
+# https://php.watch/versions/8.0/xmlrpc
+WITH_XMLRPC_CONFIGURE=""
+if [[ "${PHP_MODULE_API_VERSIONS["$php_series"]}" -lt "${PHP_MODULE_API_VERSIONS["8.0"]}" ]] ; then
+  WITH_XMLRPC_CONFIGURE="--with-xmlrpc"
+fi
+
 mkdir -p "/app/vendor/libwebp" \
   && curl "${SWIFT_URL}/package/libwebp-${webp_version}.tgz" | tar xzv -C /app/vendor/libwebp
 
@@ -136,7 +143,7 @@ ${libzip_flag} \
 --with-openssl \
 --enable-soap \
 --enable-xmlreader \
---with-xmlrpc \
+${WITH_XMLRPC_CONFIGURE} \
 --with-curl=/usr \
 --with-xsl \
 --enable-fpm \


### PR DESCRIPTION
- ds and lua extensions don't work. lua was already broken for PHP 8.0.
- XML-RPC has moved to a PECL module. Hence it's now enabled in this release.
- For the scalingo-18 stack the libzip version included in the OS is not recent enough. Hence it is not supported. (`WARNING: Libzip >= 1.2.0 needed for encryption support`)

Fix #222
Fix #223
Fix #224