### PR TITLE
release(apcu): update from 5.1.20 to 5.1.21

### DIFF
--- a/support/ext/apcu
+++ b/support/ext/apcu
@@ -5,7 +5,7 @@ set -e
 php_version=${1:=7.4}
 
 if echo $php_version | grep -q -E '^[78].' ; then
-  apcu_version=5.1.20
+  apcu_version=5.1.21
 else
   apcu_version=4.0.11
 fi


### PR DESCRIPTION
APCU changelog (https://github.com/krakjoe/apcu/releases/tag/v5.1.21):

> Fixed compatibility with PHP 8.1 by adding return types to `APCUIterator`.

Related to https://github.com/Scalingo/php-buildpack/issues/228