### PR TITLE
feat(datadog): Install Datadog Tracer and Appsec extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,43 @@ application on your dashboard.
 
     "new-relic": true
 
+#### datadog
+
+_Default: false_
+
+Enable support for [Datadog](https://www.datadoghq.com/), and specifically:
+- _Datadog APM_ with the [Datadog Tracer extension](https://github.com/DataDog/dd-trace-php/)
+- _Datadog Application Security_ with the [Datadog AppSec extension](https://github.com/DataDog/dd-appsec-php)
+
+_Important:_
+- both extensions will be installed using the Datadog AppSec installer, which is still in beta
+- the Datadog agent has to be installed first ([see the documentation](https://doc.scalingo.com/platform/app/datadog))
+
+To enable Datadog support, set the `extra.paas.datadog` property to `true`:
+
+```
+    "datadog": true
+```
+
+This will automatically install and enable the latest available version of the Datadog Tracer. To disable the Tracer
+or install a specific version, use the `DATADOG_TRACER_VERSION` environment variable (`latest` by default).
+
+Example:
+
+```
+DATADOG_TRACER_VERSION=0.71.0
+```
+
+The Datadog AppSec extension will be disabled by default. To install and enable the AppSec extension, set the
+`DATADOG_APPSEC_VERSION` environment variable to `latest` or any other valid version (`0` by default). Note that
+the AppSec extension requires the Tracer extension.
+
+Example:
+
+```
+DATADOG_APPSEC_VERSION=latest
+```
+
 #### log-files
 
 _Default: []_

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,7 @@ basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source "$basedir/../conf/buildpack.conf"
 source $basedir/common.sh
 source $basedir/../lib/composer
+source $basedir/../lib/datadog
 source $basedir/../lib/newrelic
 
 if [ "$PHP_BUILDPACK_NO_NODE" != "true" ] ; then
@@ -174,6 +175,16 @@ function package_compile_cmd() {
   jq --raw-output ".extra.${composer_extra_key}[\"compile\"] // [] | .[]" < "$BUILD_DIR/composer.json"
 }
 
+function package_datadog_enabled() {
+  local val=$(jq --raw-output ".extra.${composer_extra_key}.datadog // false" < "$BUILD_DIR/composer.json")
+
+  if [ "$val" = "true" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 function package_newrelic_enabled() {
   local val=$(jq --raw-output ".extra.${composer_extra_key}[\"new-relic\"] // false" < "$BUILD_DIR/composer.json")
 
@@ -219,6 +230,8 @@ COMPILE_CMD="${COMPILE_CMD:-}"
 NGINX_HTTP_INCLUDES="${NGINX_HTTP_INCLUDES:-}"
 NGINX_INCLUDES="${NGINX_INCLUDES:-}"
 ACCESS_LOG_FORMAT_COMPOSER_JSON="${ACCESS_LOG_FORMAT_COMPOSER_JSON:-}"
+DATADOG_TRACER_VERSION="${DATADOG_TRACER_VERSION:-latest}"
+DATADOG_APPSEC_VERSION="${DATADOG_APPSEC_VERSION:-0}"
 # Version number comes from https://download.newrelic.com/php_agent/archive/
 NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.17.1.301}"
 LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
@@ -311,6 +324,10 @@ fetch_package "ext/$(php_api_version)/php-mongodb" "/app/vendor/php" | indent
 if [ "$(php_api_version)" = "20170718" -o "$(php_api_version)" = "20180731" ] ; then
     echo "       mcrypt"
     fetch_package "ext/$(php_api_version)/php-mcrypt" "/app/vendor/php" | indent
+fi
+
+if [ -f "$BUILD_DIR/composer.json" ] && package_datadog_enabled; then
+    install_datadog "${DATADOG_TRACER_VERSION}" "${DATADOG_APPSEC_VERSION}"
 fi
 
 if [ -f "$BUILD_DIR/composer.json" ] && package_newrelic_enabled; then

--- a/lib/datadog
+++ b/lib/datadog
@@ -1,0 +1,41 @@
+function install_datadog() {
+    status "Datadog usage detected, installing PHP extensions"
+
+    local tracer_version="${1}"
+    local appsec_version="${2}"
+
+    if [ "${tracer_version}" = "0" ] && [ "${appsec_version}" = "0" ]; then
+        echo >&2 "Skipping Datadog installation, as there is nothing to install."
+    fi
+
+    local tracer_option
+    if [ "${tracer_version}" = "0" ]; then tracer_option="--no-tracer"; else tracer_option="--version=${tracer_version}"; fi
+
+    local appsec_option
+    if [ "${appsec_version}" = "0" ]; then appsec_option="--no-appsec"; else appsec_option="--version=${appsec_version}"; fi
+
+    local install_dir="${BUILD_DIR}/vendor/datadog"
+    local cwd=$(pwd)
+    local temp_dir=$(mktmpdir "datadog")
+
+    cd "${tempdir}"
+
+    # the AppSec extension is in public beta right now, and the URL of the installer might change in the future
+    curl --silent -L "https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php" > dd-library-php-setup.php
+    mkdir -p ${install_dir}
+    php dd-library-php-setup.php ${tracer_option} ${appsec_option} --php-bin=all --install-dir=${install_dir}
+
+    [ -f '/app/vendor/php/etc/conf.d/98-ddtrace.ini' ] && sed -i "s@$BUILD_DIR@/app@g" /app/vendor/php/etc/conf.d/98-ddtrace.ini
+    [ -f '/app/vendor/php/etc/conf.d/98-ddappsec.ini' ] && sed -i "s@$BUILD_DIR@/app@g" /app/vendor/php/etc/conf.d/98-ddappsec.ini
+
+    if [ "${appsec_option}" != "--no-appsec" ]; then
+        mkdir -p "${BUILD_DIR}/.profile.d"
+        local startup_script="${BUILD_DIR}/.profile.d/datadog.sh"
+        # startup_script should have been created by the Datadog Agent buildpack, but let's make sure it's here anyway
+        touch "${startup_script}"
+        chmod +x "${startup_script}"
+        echo "export DD_APPSEC_ENABLED=${DD_APPSEC_ENABLED:=true}" >> "${startup_script}"
+    fi
+
+    cd "${cwd}"
+}


### PR DESCRIPTION
Hi Scalingo,

This PR is my attempt to install [Datadog Application Security](https://docs.datadoghq.com/fr/security_platform/application_security/) extension, following the [install instructions](https://github.com/DataDog/dd-appsec-php).

---

**ORIGINAL POST** (2021-03-09):

It does not work right now and I am facing this issue:
```
-----> Installing Datadog Tracer and AppSec extension
sh: 1: ldconfig: not found
ERROR: Cannot find library 'libcurl'
Failed command (return code 1): ldconfig -p | grep libcurl
```

It looks like `ldconfig` is not available in the build, though I had no problem when testing locally with the [scalingo/scalingo-18](https://hub.docker.com/r/scalingo/scalingo-18) docker image :thinking: 

What's wrong with ldconfig?

---

**UPDATE** (2021-03-11):

:partying_face: It now works:
- make sure to [setup the Datadog Agent](https://doc.scalingo.com/platform/app/datadog) with the datadog buildpack
- in `composer.json`, set key `extra.paas.datadog` to `true` to install and enable the Datadog Tracer
- set env var `DATADOG_APPSEC_VERSION=latest` to install and enable Datadog Application Security