### PR TITLE
fix(newrelic): upgrade from 9.17.1.301 to 9.21.0.311 by default

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -251,7 +251,7 @@ DATADOG_TRACER_VERSION="${DATADOG_TRACER_VERSION:-latest}"
 DATADOG_APPSEC_VERSION="${DATADOG_APPSEC_VERSION:-0}"
 SCOUT_APM_VERSION=${SCOUT_APM_VERSION:-1.7.0}
 # Version number comes from https://download.newrelic.com/php_agent/archive/
-NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.17.1.301}"
+NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.21.0.311}"
 LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
 
 # Display a warning that Composer version 1.x is End of Life


### PR DESCRIPTION
9.21.0.311 adds support for PHP 8.1

Fix #239