### PR TITLE
[SRE-682] Use official S3 nodejs repository instead of legacy heroku.com URL

### DIFF
--- a/lib/nodejs
+++ b/lib/nodejs
@@ -59,7 +59,7 @@ function compile_node() {
 
   # Download node from Heroku's S3 mirror of nodejs.org/dist
   status "Downloading and installing node"
-  node_url="https://s3pository.heroku.com/node/v$node_version/node-v$node_version-linux-x64.tar.gz"
+  node_url="https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v${node_version}-linux-x64.tar.gz"
   curl $node_url --location -s -o - | tar xzf - -C $build_dir
 
   # Move node into ./vendor and make it executable


### PR DESCRIPTION
Fixes [SRE-682]

[SRE-682]: https://scalingo.atlassian.net/browse/SRE-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ