### PR TITLE
chore(igbinary): update to 3.2.9

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -41,5 +41,5 @@ webp_version="1.2.1" # Can be found here: https://storage.googleapis.com/downloa
 libonig_version="6.9.7.1"
 # From https://zlib.net/
 zlib_version="1.2.11"
-igbinary_version="3.2.7"
+igbinary_version="3.2.9"
 amqp_version="1.11.0"


### PR DESCRIPTION
Update igbinary extension to 3.2.9.

First step to fix #271.