### PR TITLE
fix: ignore ds and lua ext. with php 8.2

### DIFF
--- a/support/package_all
+++ b/support/package_all
@@ -23,7 +23,7 @@ done
 
 for e in ./ext/*; do
   ext_name=$(basename $e)
-  if [[ "$php_version" = "8.1" ]]; then
+  if [[ "$php_version" = "8.1" || "$php_version" = "8.2" ]]; then
     if [[ "$ext_name" = "ds" ]]; then
       continue
     fi


### PR DESCRIPTION
The `ds` and `lua` extensions are ignored starting with PHP 8.1.
(They don't compile)