### PR TITLE
release(new-relic): upgrade default from 9.21.0.311 to 10.4.0.316

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -251,7 +251,7 @@ DATADOG_TRACER_VERSION="${DATADOG_TRACER_VERSION:-latest}"
 DATADOG_APPSEC_VERSION="${DATADOG_APPSEC_VERSION:-0}"
 SCOUT_APM_VERSION=${SCOUT_APM_VERSION:-1.7.0}
 # Version number comes from https://download.newrelic.com/php_agent/archive/
-NEWRELIC_VERSION="${NEWRELIC_VERSION:=9.21.0.311}"
+NEWRELIC_VERSION="${NEWRELIC_VERSION:=10.4.0.316}"
 LOG_FILES=( "/app/vendor/nginx/logs/access.log" "/app/vendor/nginx/logs/error.log" "/app/vendor/php/var/log/error.log" )
 
 # Display a warning that Composer version 1.x is End of Life


### PR DESCRIPTION
Should add support for PHP 8.2.
https://download.newrelic.com/php_agent/archive/10.4.0.316/