### PR TITLE
feat(composer): install PECL extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ support.
 * Lightweight stack compared to Apache-ModPHP
 * Composer support
 * Various frameworks support out of the box (no configuration)
-* Dynamic installing of [supported extensions](support/ext) listed as `ext-` requirements in `composer.json`.
+* Dynamic installing of PHP extensions, listed as `ext-` requirements in `composer.json`.
+* Interfacing with PECL platform to download and build extensions dynamically
 
 ## How to use it
 
@@ -414,6 +415,58 @@ A tail on each unique log file will be run at application startup
         "vendor/nginx/stuff.log"
     ],
 
+
+### PHP Extensions
+
+Different types of extensions can be added to the PHP runtime, with different
+levels of compatibility. All these extensions can be added in the `require`
+block of the `composer.json` and this buildpack will try to install them.
+
+```
+{
+  ...
+  "require": {
+    "ext-sodium": "*",
+    "ext-calendar": "*",
+  }
+}
+```
+
+#### Internal PHP Extensions
+
+The PHP binary is not built with all modules embedded. To reduce build size and
+attack surface, these extensions have to be enabled manually. The supported list
+can be found here: https://github.com/Scalingo/php-buildpack/tree/master/support/ext-internal
+
+#### PECL PHP Extensions
+
+PECL extensions are registered on the https://pecl.php.net platform. This
+buildpack will try to download and build them during deployments.
+
+Some extensions may require system dependencies absent from the stack your
+application is based on. In this case you're encouraged to prepend the [APT
+Buildpack](https://doc.scalingo.com/platform/deployment/buildpacks/apt) and
+install the missing package according to the extension documentation.
+
+You may need to add extra compilation flags, in this case define them through
+environment variables with the following pattern:
+
+```
+# replace $extension_name by the right extension name
+PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name="--flag-to-add"
+```
+
+If the extension you are trying to install is a Zend extension, please define
+
+```
+# replace $extension_name by the right extension name
+PHP_PECL_EXTENSION_IS_ZEND_$extension_name=true
+```
+
+#### Third Party PHP Extensions
+
+Some third party extensions can also be installed, list can be found here
+https://github.com/Scalingo/php-buildpack/tree/master/support/ext
 
 ## Node.js
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,10 +8,12 @@ shopt -s dotglob
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source "$basedir/../conf/buildpack.conf"
 source $basedir/common.sh
+source $basedir/../lib/package
 source $basedir/../lib/composer
 source $basedir/../lib/datadog
 source $basedir/../lib/scout
 source $basedir/../lib/newrelic
+source $basedir/../lib/apt
 source $basedir/../lib/pecl
 source $basedir/../lib/pecl_oci8
 
@@ -31,48 +33,6 @@ cd "$BUILD_DIR"
 mkdir -p "$CACHE_DIR/package"
 
 export APP_ENV=${APP_ENV:-prod}
-
-function fetch_engine_package() {
-    local engine="$1"
-    local version="$2"
-    local location="$3"
-
-    local base_url="$PHP_BASE_URL"
-    if [ "$engine" = "nginx" ] ; then
-      base_url="$NGINX_BASE_URL"
-    fi
-
-    fetch_package "$base_url" "${engine}-${version}" "$location"
-}
-
-function fetch_package() {
-    local base_url="$1"
-    local package="$2"
-    local location="$3"
-
-    mkdir -p "$location"
-
-    local checksum_url="${base_url}/package/${package}.md5"
-    local package_url="${base_url}/package/${package}.tgz"
-    local checksum=$(curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$checksum_url" 2> /dev/null)
-    local cache_checksum=""
-
-    if [ -f "$CACHE_DIR/package/${package}.md5" ]; then
-        local cache_checksum=$(cat "$CACHE_DIR/package/${package}.md5")
-    fi
-
-    mkdir -p "$CACHE_DIR/package/$(dirname "$package")"
-
-    if [ "$cache_checksum" != "$checksum" ]; then
-        curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$package_url" -L -s > "$CACHE_DIR/package/${package}.tgz"
-        echo "$checksum" > "$CACHE_DIR/package/${package}.md5"
-    else
-        echo "Checksums match. Fetching from cache."
-    fi
-
-    mkdir -p "$location"
-    tar xzf "$CACHE_DIR/package/${package}.tgz" -C "$location"
-}
 
 function detect_framework() {
   BUILD_DIR=$1

--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,7 @@ source $basedir/../lib/composer
 source $basedir/../lib/datadog
 source $basedir/../lib/scout
 source $basedir/../lib/newrelic
+source $basedir/../lib/pecl
 
 if [ "$PHP_BUILDPACK_NO_NODE" != "true" ] ; then
   source $basedir/../lib/nodejs

--- a/lib/apt
+++ b/lib/apt
@@ -1,0 +1,32 @@
+function apt_install() {
+  local apt_deps="${1}"
+  local build_dir="${2}"
+  local cache_dir="${3}"
+  local env_dir="${4}"
+
+  apt_manifest="$(mktemp "${build_dir}/Aptfile.php-XXX")"
+  echo "${apt_deps}" | tr ' ' '\n' > "${apt_manifest}"
+
+  apt_deps_buildpack_dir=$(mktemp /tmp/apt_buildpack_XXXX)
+  rm "${apt_deps_buildpack_dir}"
+
+  readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
+  git clone --quiet --depth=1 "${apt_buildpack_url}" "${apt_deps_buildpack_dir}" >/dev/null 2>/dev/null
+
+  readonly apt_log_file=$(mktemp /tmp/apt_log_XXXX.log)
+  APT_FILE_MANIFEST="$(basename ${apt_manifest})" "${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" >"${apt_log_file}" 2>&1
+  if [ $? -ne 0 ] ; then 
+    tail -n 30 "${apt_log_file}" | indent
+    echo
+    warn "Fail to install apt packages"
+    echo
+    exit 1
+  fi
+
+  # Source new libs for future buildpack (update of LD_LIBRARY_PATH)
+  export_file="${build_dir}/oci8_apt_export"
+  cp "${apt_deps_buildpack_dir}/export" "${export_file}"
+
+  rm "${apt_manifest}"
+  echo "${export_file}"
+}

--- a/lib/apt
+++ b/lib/apt
@@ -18,7 +18,7 @@ function apt_install() {
   if [ $? -ne 0 ] ; then
     tail -n 30 "${apt_log_file}" | indent
     echo
-    warn "Fail to install apt packages"
+    warn "Fail to install apt packages $apt_deps"
     echo
     exit 1
   fi

--- a/lib/apt
+++ b/lib/apt
@@ -11,11 +11,11 @@ function apt_install() {
   rm "${apt_deps_buildpack_dir}"
 
   readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
-  git clone --quiet --depth=1 "${apt_buildpack_url}" "${apt_deps_buildpack_dir}" >/dev/null 2>/dev/null
+  git clone --quiet --depth=1 "${apt_buildpack_url}" "${apt_deps_buildpack_dir}" >/dev/null 2>&1
 
   readonly apt_log_file=$(mktemp /tmp/apt_log_XXXX.log)
   APT_FILE_MANIFEST="$(basename ${apt_manifest})" "${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" >"${apt_log_file}" 2>&1
-  if [ $? -ne 0 ] ; then 
+  if [ $? -ne 0 ] ; then
     tail -n 30 "${apt_log_file}" | indent
     echo
     warn "Fail to install apt packages"
@@ -24,9 +24,5 @@ function apt_install() {
   fi
 
   # Source new libs for future buildpack (update of LD_LIBRARY_PATH)
-  export_file="${build_dir}/oci8_apt_export"
-  cp "${apt_deps_buildpack_dir}/export" "${export_file}"
-
-  rm "${apt_manifest}"
-  echo "${export_file}"
+  echo "${apt_deps_buildpack_dir}/export"
 }

--- a/lib/composer
+++ b/lib/composer
@@ -65,9 +65,7 @@ function install_composer_deps() {
         for ext in $required_extensions; do
             local apt_deps=""
             local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
-            local should_install_from_pecl="true"
 
-            # TODO: Find a better way to ignore extensions which were not found in S3
             if [ "$ext" = "oci8" ] ; then
               apt_deps="libaio-dev"
             fi

--- a/lib/composer
+++ b/lib/composer
@@ -50,7 +50,7 @@ function install_composer_deps() {
         chmod a+x "$CACHE_DIR/composer.phar"
         echo "$checksum" > $CACHE_DIR/composer.phar.md5
     else
-        echo "Checksums match. Fetching from cache."
+        echo "Checksums match. Fetching Composer from cache."
     fi
 
     cp "$CACHE_DIR/composer.phar" "$target/vendor/composer/bin/"
@@ -76,13 +76,19 @@ function install_composer_deps() {
                 sodium_version=$sodium_php72_php73_version
               fi
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
+            else
+              # TODO How to check if the extension is in the cache?
+              local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
+              install_pecl_extension $ext "$ext_version" | indent
             fi
+
+            # TODO I don't think this instruction should be executed for all extensions
             fetch_package "$PHP_BASE_URL" "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
         done
     fi
 
     if [ -n "$COMPOSER_GITHUB_TOKEN" ]; then
-        status "Configuring the github authentication for Composer"
+        status "Configuring the GitHub authentication for Composer"
         php "vendor/composer/bin/composer.phar" config -g github-oauth.github.com "$COMPOSER_GITHUB_TOKEN" --no-interaction
     fi
 
@@ -101,4 +107,3 @@ function install_composer_deps() {
         cd "$cwd"
     } | indent
 }
-

--- a/lib/composer
+++ b/lib/composer
@@ -50,7 +50,7 @@ function install_composer_deps() {
         chmod a+x "$CACHE_DIR/composer.phar"
         echo "$checksum" > $CACHE_DIR/composer.phar.md5
     else
-        echo "Checksums match. Fetching Composer from cache."
+        echo "Checksums match. Fetching Composer from cache." |indent
     fi
 
     cp "$CACHE_DIR/composer.phar" "$target/vendor/composer/bin/"
@@ -63,9 +63,27 @@ function install_composer_deps() {
     if [ -n "$required_extensions" ]; then
         status "Bundling additional extensions"
         for ext in $required_extensions; do
-            echo "$ext" | indent
+            local apt_deps=""
+            local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
+            local should_install_from_pecl="true"
+
             # TODO: Find a better way to ignore extensions which were not found in S3
-            if [ "$ext" = "memcached" ] ; then
+            if [ "$ext" = "oci8" ] ; then
+              apt_deps="libaio-dev"
+            fi
+
+            if [ -n "$apt_deps" ] ; then
+              echo "Installing dependencies for ${ext}: ${apt_deps}" | indent
+              install_env_file="$(apt_install "${apt_deps}" "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}")"
+              # Source environment to export LD_LIBRARY_PATH
+              source "${install_env_file}"
+              rm "${install_env_file}"
+            fi
+
+            # Install third-party dependencies after ubuntu packages have been added
+            if [ "$ext" = "oci8" ] ; then
+              install_oracle_client_extension "${BUILD_DIR}" "${CACHE_DIR}"
+            elif [ "$ext" = "memcached" ] ; then
               fetch_package "$PHP_BASE_URL" "libmemcached-${libmemcached_version}" "/app/vendor/libmemcached" | indent
             elif [ "$ext" = "gmp" ] ; then
               fetch_package "$PHP_BASE_URL" "gmp-${gmp_version}" "/app/vendor/gmp" | indent
@@ -76,21 +94,16 @@ function install_composer_deps() {
                 sodium_version=$sodium_php72_php73_version
               fi
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
-            else
-              if [[ $ext = 'oci8' ]]; then
-                echo "Installing libaio for oci8" | indent
-                install_env_file="$(install_apt_libaio "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}")"
-                # Source environment to export LD_LIBRARY_PATH
-                source "${install_env_file}"
-                rm "${install_env_file}"
-
-                install_oracle_client_extension "${BUILD_DIR}" "${CACHE_DIR}"
-              fi
-              local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
-              install_pecl_extension $ext "$ext_version" "${BUILD_DIR}" "$CACHE_DIR" | indent
             fi
-            # TODO I don't think this instruction should be executed for all extensions
-            fetch_package "$PHP_BASE_URL" "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
+
+            local extension_package_path="ext/$(php_api_version)/php-${ext}"
+            package_found="$(has_package "${PHP_BASE_URL}" "${extension_package_path}")"
+            if [ "${package_found}" = "true" ] ; then
+              echo "Installing PHP extension: ${ext}" | indent
+              fetch_package "${PHP_BASE_URL}" "${extension_package_path}" "/app/vendor/php"
+            else
+              install_pecl_extension "${ext}" "${ext_version}" "${BUILD_DIR}" "$CACHE_DIR"
+            fi
         done
     fi
 

--- a/lib/composer
+++ b/lib/composer
@@ -77,9 +77,8 @@ function install_composer_deps() {
               fi
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
             else
-              # TODO How to check if the extension is in the cache?
               local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
-              install_pecl_extension $ext "$ext_version" | indent
+              install_pecl_extension $ext "$ext_version" "$CACHE_DIR" | indent
             fi
 
             # TODO I don't think this instruction should be executed for all extensions

--- a/lib/package
+++ b/lib/package
@@ -44,12 +44,12 @@ function fetch_package() {
     mkdir -p "$CACHE_DIR/package/$(dirname "$package")"
 
     if [ "$cache_checksum" != "$checksum" ]; then
-        curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$package_url" -L -s > "$CACHE_DIR/package/${package}.tgz"
+        curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$package_url" --location --silent > "$CACHE_DIR/package/${package}.tgz"
         echo "$checksum" > "$CACHE_DIR/package/${package}.md5"
     else
         echo "Checksums match. Fetching from cache." | indent
     fi
 
     mkdir -p "$location"
-    tar xzf "$CACHE_DIR/package/${package}.tgz" -C "$location"
+    tar xzf "$CACHE_DIR/package/${package}.tgz" --directory "$location"
 }

--- a/lib/package
+++ b/lib/package
@@ -1,0 +1,55 @@
+function fetch_engine_package() {
+    local engine="$1"
+    local version="$2"
+    local location="$3"
+
+    local base_url="$PHP_BASE_URL"
+    if [ "$engine" = "nginx" ] ; then
+      base_url="$NGINX_BASE_URL"
+    fi
+
+    fetch_package "$base_url" "${engine}-${version}" "$location"
+}
+
+function has_package() {
+    local base_url="${1}"
+    local package="${2}"
+
+    local package_url="${base_url}/package/${package}.tgz"
+
+    curl --output /dev/null --silent --head --location --fail "${package_url}"
+    if [ $? -eq 0 ] ; then
+      echo "true"
+    else
+      echo "false"
+    fi
+}
+
+function fetch_package() {
+    local base_url="$1"
+    local package="$2"
+    local location="$3"
+
+    mkdir -p "$location"
+
+    local checksum_url="${base_url}/package/${package}.md5"
+    local package_url="${base_url}/package/${package}.tgz"
+    local checksum=$(curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$checksum_url" 2> /dev/null)
+    local cache_checksum=""
+
+    if [ -f "$CACHE_DIR/package/${package}.md5" ]; then
+        local cache_checksum=$(cat "$CACHE_DIR/package/${package}.md5")
+    fi
+
+    mkdir -p "$CACHE_DIR/package/$(dirname "$package")"
+
+    if [ "$cache_checksum" != "$checksum" ]; then
+        curl --fail --retry 3 --retry-delay 2 --connect-timeout 3 --max-time 30 "$package_url" -L -s > "$CACHE_DIR/package/${package}.tgz"
+        echo "$checksum" > "$CACHE_DIR/package/${package}.md5"
+    else
+        echo "Checksums match. Fetching from cache." | indent
+    fi
+
+    mkdir -p "$location"
+    tar xzf "$CACHE_DIR/package/${package}.tgz" -C "$location"
+}

--- a/lib/pecl
+++ b/lib/pecl
@@ -4,7 +4,7 @@ function enable_pecl_extension() {
   local is_zend_extension_var_name="PHP_PECL_EXTENSION_IS_ZEND_$extension_name"
   local is_zend_extension=$(printenv $is_zend_extension_var_name)
 
-  if [[ -z $is_zend_extension ]] ; then
+  if [[ $is_zend_extension = "true" ]] ; then
     echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
   else
     echo "zend_extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
@@ -40,8 +40,9 @@ function install_pecl_extension() {
 
   local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
   local configure_extension_args=$(printenv $configure_extension_args_var_name)
+  local flags=$(echo $configure_extension_args | sed "s/\$BUILD_DIR/$build_dir/")
 
-  ./configure --with-php-config=/app/vendor/php/bin/php-config $configure_extension_args > /dev/null
+  ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null
 
   make > /dev/null
   cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"

--- a/lib/pecl
+++ b/lib/pecl
@@ -40,7 +40,7 @@ function install_pecl_extension() {
 
   local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
   local configure_extension_args=$(printenv $configure_extension_args_var_name)
-  local flags=$(echo $configure_extension_args | sed "s/\$BUILD_DIR/$build_dir/")
+  local flags=$(echo $configure_extension_args | sed "s|\$BUILD_DIR|$build_dir|")
 
   ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null
 

--- a/lib/pecl
+++ b/lib/pecl
@@ -4,10 +4,10 @@ function enable_pecl_extension() {
   local is_zend_extension_var_name="PHP_PECL_EXTENSION_IS_ZEND_$extension_name"
   local is_zend_extension=$(printenv $is_zend_extension_var_name)
 
-  if [[ -z $is_zend_extension ]] ; then 
+  if [[ -z $is_zend_extension ]] ; then
     echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
   else
-    echo "zen_extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+    echo "zend_extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
   fi
 }
 

--- a/lib/pecl
+++ b/lib/pecl
@@ -1,3 +1,16 @@
+
+function enable_pecl_extension() {
+  local extension_name="${1}"
+  local is_zend_extension_var_name="PHP_PECL_EXTENSION_IS_ZEND_$extension_name"
+  local is_zend_extension=$(printenv $is_zend_extension_var_name)
+
+  if [[ -z $is_zend_extension ]] ; then 
+    echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+  else
+    echo "zen_extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+  fi
+}
+
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"
@@ -9,7 +22,7 @@ function install_pecl_extension() {
   if [ -f "${cache_extension_file}" ]; then
     echo "Installing PECL extension ${extension_name} version ${version} from the cache"
     cp "${cache_extension_file}" "${ext_dir}/${extension_name}.so"
-    echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+    enable_pecl_extension ${extension_name}
     return
   fi
 
@@ -29,7 +42,7 @@ function install_pecl_extension() {
   make > /dev/null
   cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"
   cp modules/${extension_name}.so "${cache_extension_file}"
-  echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+  enable_pecl_extension ${extension_name}
 
   popd > /dev/null
   popd > /dev/null

--- a/lib/pecl
+++ b/lib/pecl
@@ -37,7 +37,11 @@ function install_pecl_extension() {
 
   pushd ${extension_name}-${version} > /dev/null
   /app/vendor/php/bin/phpize > /dev/null
-  ./configure --with-php-config=/app/vendor/php/bin/php-config --with-${extension_name}=${build_dir}/.apt/usr > /dev/null
+
+  local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
+  local configure_extension_args=$(printenv $configure_extension_args_var_name)
+
+  ./configure --with-php-config=/app/vendor/php/bin/php-config $configure_extension_args > /dev/null
 
   make > /dev/null
   cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"

--- a/lib/pecl
+++ b/lib/pecl
@@ -5,9 +5,9 @@ function enable_pecl_extension() {
   local is_zend_extension=$(printenv $is_zend_extension_var_name)
 
   if [[ $is_zend_extension = "true" ]] ; then
-    echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
-  else
     echo "zend_extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+  else
+    echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
   fi
 }
 

--- a/lib/pecl
+++ b/lib/pecl
@@ -1,12 +1,22 @@
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"
+  local cache_dir="${3}"
+
+  local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
+
+  local cache_extension_file="${cache_dir}/${extension_name}-${version}.so"
+  if [ -f "${cache_extension_file}" ]; then
+    echo "Installing PECL extension ${extension_name} version ${version} from the cache"
+    cp "${cache_extension_file}" "${ext_dir}/${extension_name}.so"
+    echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+    return
+  fi
 
   local build_dir=$(pwd)
-  local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
   local temp_dir=$(mktmpdir "pecl-extension")
 
-  status "Installing PHP extension ${extension_name} version ${version}"
+  echo "Installing PECL extension ${extension_name} version ${version}"
 
   pushd "${temp_dir}" > /dev/null
 
@@ -18,6 +28,7 @@ function install_pecl_extension() {
 
   make > /dev/null
   cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"
+  cp modules/${extension_name}.so "${cache_extension_file}"
   echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
 
   popd > /dev/null

--- a/lib/pecl
+++ b/lib/pecl
@@ -1,0 +1,25 @@
+function install_pecl_extension() {
+  local extension_name="${1}"
+  local version="${2}"
+
+  local build_dir=$(pwd)
+  local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
+  local temp_dir=$(mktmpdir "pecl-extension")
+
+  status "Installing PHP extension ${extension_name} version ${version}"
+
+  pushd "${temp_dir}" > /dev/null
+
+  curl --silent --location "https://pecl.php.net/get/${extension_name}-${version}.tgz" | tar xz
+
+  pushd ${extension_name}-${version} > /dev/null
+  /app/vendor/php/bin/phpize > /dev/null
+  ./configure --with-php-config=/app/vendor/php/bin/php-config --with-${extension_name}=${build_dir}/.apt/usr > /dev/null
+
+  make > /dev/null
+  cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"
+  echo "extension=${extension_name}.so" > "/app/vendor/php/etc/conf.d/${extension_name}.ini"
+
+  popd > /dev/null
+  popd > /dev/null
+}

--- a/lib/pecl
+++ b/lib/pecl
@@ -1,3 +1,61 @@
+function install_pecl_extension() {
+  local extension_name="${1}"
+  local version="${2}"
+  local cache_dir="${3}"
+
+  if [[ $version = '*' ]]; then
+    local version=$(curl --silent "https://pecl.php.net/rest/r/$extension_name/latest.txt")
+  fi
+  local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
+
+  local cache_extension_file="${cache_dir}/${extension_name}-${version}.so"
+  if [ -f "${cache_extension_file}" ]; then
+    echo "Installing PECL extension ${extension_name} version ${version} from the cache" | indent
+    cp "${cache_extension_file}" "${ext_dir}/${extension_name}.so"
+    enable_pecl_extension ${extension_name}
+    return
+  fi
+
+  local build_dir=$(pwd)
+  local temp_dir=$(mktmpdir "pecl-extension")
+
+  echo "Installing PECL extension ${extension_name} version ${version}" | indent
+
+  pushd "${temp_dir}" > /dev/null
+
+  curl --silent --location "https://pecl.php.net/get/${extension_name}-${version}.tgz" | tar xz
+
+  pushd ${extension_name}-${version} > /dev/null
+  (
+    set +e
+    readonly phpize_log_file=$(mktemp "/tmp/pecl-phpize-${extension_name}-XXXX.log")
+    /app/vendor/php/bin/phpize > "${phpize_log_file}" 2>&1
+    [ $? -eq 0 ] || install_pecl_error "${extension_name}" "package" "${phpize_log_file}"
+
+    local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
+    local configure_extension_args=$(printenv $configure_extension_args_var_name)
+    local flags=$(echo $configure_extension_args | sed "s|\$BUILD_DIR|$build_dir|")
+
+    if [[ $extension_name = 'oci8' ]]; then
+      flags="--with-oci8=instantclient,${ORACLE_HOME}"
+    fi
+
+    readonly configure_log_file=$(mktemp "/tmp/pecl-configure-${extension_name}-XXXX.log")
+    ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > "${configure_log_file}" 2>&1
+    [ $? -eq 0 ] || install_pecl_error "${extension_name}" "configure build" "${configure_log_file}"
+
+    readonly make_log_file=$(mktemp "/tmp/pecl-make-${extension_name}-XXXX.log")
+    make -j 2 > "${make_log_file}" 2>&1
+    [ $? -eq 0 ] || install_pecl_error "${extension_name}" "compile" "${make_log_file}"
+  )
+
+  cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"
+  cp modules/${extension_name}.so "${cache_extension_file}"
+  enable_pecl_extension ${extension_name}
+
+  popd > /dev/null
+  popd > /dev/null
+}
 
 function enable_pecl_extension() {
   local extension_name="${1}"
@@ -11,55 +69,19 @@ function enable_pecl_extension() {
   fi
 }
 
-function install_pecl_extension() {
+function install_pecl_error() {
   local extension_name="${1}"
-  local version="${2}"
-  local cache_dir="${3}"
+  local action="${2}"
+  local log_file="${3}"
 
-  if [[ $version = '*' ]]; then
-    local version=$(curl --silent "https://pecl.php.net/rest/r/$extension_name/latest.txt")
-  fi
-  local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
-
-  local cache_extension_file="${cache_dir}/${extension_name}-${version}.so"
-  if [ -f "${cache_extension_file}" ]; then
-    echo "Installing PECL extension ${extension_name} version ${version} from the cache"
-    cp "${cache_extension_file}" "${ext_dir}/${extension_name}.so"
-    enable_pecl_extension ${extension_name}
-    return
-  fi
-
-  local build_dir=$(pwd)
-  local temp_dir=$(mktmpdir "pecl-extension")
-
-  echo "Installing PECL extension ${extension_name} version ${version}"
-
-  pushd "${temp_dir}" > /dev/null
-
-  curl --silent --location "https://pecl.php.net/get/${extension_name}-${version}.tgz" | tar xz
-
-  pushd ${extension_name}-${version} > /dev/null
-
-  /app/vendor/php/bin/phpize &> /dev/null
-
-  local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
-  local configure_extension_args=$(printenv $configure_extension_args_var_name)
-  local flags=$(echo $configure_extension_args | sed "s|\$BUILD_DIR|$build_dir|")
-
-  if [[ $extension_name = 'oci8' ]]; then
-    if [ -e "${3}/${apt_deps_buildpack_dir}/export" ]; then
-      source "${3}/${apt_deps_buildpack_dir}/export"
-    fi
-    flags="--with-oci8=instantclient,${ORACLE_HOME}"
-  fi
-
-  ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null
-
-  make > /dev/null
-  cp modules/${extension_name}.so "${ext_dir}/${extension_name}.so"
-  cp modules/${extension_name}.so "${cache_extension_file}"
-  enable_pecl_extension ${extension_name}
-
-  popd > /dev/null
-  popd > /dev/null
+  echo
+  tail -n 30 "${log_file}" | indent
+  echo
+  # This sleep prevents from having the following lines mixed up with the output
+  # of the above tail. Mystery of shellscripting.
+  sleep 0.1
+  warn "Fail to ${action} of PHP PECL extension: ${extension_name}"
+  echo "Read above logs to understand the source of the issue" | indent
+  echo
+  exit 1
 }

--- a/lib/pecl
+++ b/lib/pecl
@@ -16,6 +16,9 @@ function install_pecl_extension() {
   local version="${2}"
   local cache_dir="${3}"
 
+  if [[ $version = '*' ]]; then
+    local version=$(curl --silent "https://pecl.php.net/rest/r/$extension_name/latest.txt")
+  fi
   local ext_dir=/app/vendor/php/lib/php/extensions/no-debug-non-zts-$(php_api_version)
 
   local cache_extension_file="${cache_dir}/${extension_name}-${version}.so"

--- a/lib/pecl_oci8
+++ b/lib/pecl_oci8
@@ -1,27 +1,3 @@
-function install_apt_libaio() {
-  # ----
-  # Install libaio to install oci8
-  local build_dir="${1}"
-  local cache_dir="${2}"
-  local env_dir="${3}"
-
-  echo "libaio1" > "${build_dir}/Aptfile"
-
-  apt_deps_buildpack_dir=$(mktemp apt_buildpack_XXXX)
-  rm "${apt_deps_buildpack_dir}"
-
-  readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
-  git clone --quiet --depth=1 "${apt_buildpack_url}" "${build_dir}/$apt_deps_buildpack_dir" >/dev/null 2>/dev/null
-
-  "${build_dir}/${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" > /dev/null
-
-  # Source new libs for future buildpack (update of LD_LIBRARY_PATH)
-  export_file="${build_dir}/oci8_apt_export"
-  cp "${build_dir}/${apt_deps_buildpack_dir}/export" "${export_file}"
-
-  echo "${export_file}"
-}
-
 function install_oracle_client_extension() {
   # ----
   # Install oracle client
@@ -42,7 +18,9 @@ function install_oracle_client_extension() {
   unzip -q oraclesdk.zip -d "${oracle_install_dir}"
   rm oraclesdk.zip
 
-  local startup_script="${1}/.profile.d/oracle-client.sh"
-  echo "export ORACLE_HOME=${ORACLE_HOME}" >> "${startup_script}"
-  echo "export LD_LIBRARY_PATH=${ORACLE_HOME}/lib:${ORACLE_HOME}:\${LD_LIBRARY_PATH}" >> "${startup_script}"
+  readonly startup_script="${1}/.profile.d/oracle-client.sh"
+  # Replacing build_dir by /app, final location of the image data.
+  runtime_oracle_home="$(echo "${ORACLE_HOME}" | sed -e "s+${build_dir}+/app+")"
+  echo "export ORACLE_HOME=${runtime_oracle_home}" >> "${startup_script}"
+  echo "export LD_LIBRARY_PATH=${runtime_oracle_home}/lib:${runtime_oracle_home}:\${LD_LIBRARY_PATH}" >> "${startup_script}"
 }


### PR DESCRIPTION
I went through the PECL download statistics (https://pecl.php.net/package-stats.php) and tested a bunch of the packages from there. The PHP info is here: https://biniou.osc-fr1.scalingo.io/. Some of these packages are really old so I didn't tested them. I tried to find some packages that are still maintained:
- Swoole (https://pecl.php.net/package/swoole): works easily
- YAML (https://pecl.php.net/package/yaml): also needs the APT buildpack to install `libyaml-dev`
- TimezoneDB (https://pecl.php.net/package/timezonedb): works easily
- amqp (https://pecl.php.net/package/amqp): also needs the APT buildpack to install `librabbitmq-dev`

Fix #249