### PR TITLE
feat(oci8): support `oci8` extensions

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -475,6 +475,7 @@ mv /app/vendor/php vendor/php
 [ -d "/app/vendor/libtidy" ] && mv /app/vendor/libtidy vendor/libtidy
 [ -d "/app/vendor/libsodium" ] && mv /app/vendor/libsodium vendor/libsodium
 [ -d "/app/vendor/libwebp" ] && mv /app/vendor/libwebp vendor/libwebp
+[ -d "/app/vendor/oracle-client" ] && mv /app/vendor/oracle-client vendor/oracle-client
 
 mkdir -p "bin" "vendor/bin"
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,7 @@ source $basedir/../lib/datadog
 source $basedir/../lib/scout
 source $basedir/../lib/newrelic
 source $basedir/../lib/pecl
+source $basedir/../lib/pecl_oci8
 
 if [ "$PHP_BUILDPACK_NO_NODE" != "true" ] ; then
   source $basedir/../lib/nodejs
@@ -24,6 +25,7 @@ fi
 
 BUILD_DIR="$1"
 CACHE_DIR="$2"
+ENV_DIR="$3"
 
 cd "$BUILD_DIR"
 mkdir -p "$CACHE_DIR/package"
@@ -417,7 +419,7 @@ if [ "$PHP_BUILDPACK_NO_NODE" != "true" ] ; then
   install_node_deps "$BUILD_DIR"
 fi
 
-install_composer_deps "$BUILD_DIR"
+install_composer_deps "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
 
 # Detect PHP framework
 # Set FRAMEWORK if not set in environment by user

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# set -e
+set -e
 
 set -o pipefail
 shopt -s dotglob

--- a/bin/compile
+++ b/bin/compile
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+# set -e
 
 set -o pipefail
 shopt -s dotglob

--- a/lib/composer
+++ b/lib/composer
@@ -78,8 +78,13 @@ function install_composer_deps() {
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
             else
               if [[ $ext = 'oci8' ]]; then
-                install_apt_libaio "${BUILD_DIR}" "$CACHE_DIR"
-                install_oracle_client_extension "${BUILD_DIR}"
+                echo "Installing libaio for oci8" | indent
+                install_env_file="$(install_apt_libaio "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}")"
+                # Source environment to export LD_LIBRARY_PATH
+                source "${install_env_file}"
+                rm "${install_env_file}"
+
+                install_oracle_client_extension "${BUILD_DIR}" "${CACHE_DIR}"
               fi
               local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
               install_pecl_extension $ext "$ext_version" "${BUILD_DIR}" "$CACHE_DIR" | indent

--- a/lib/composer
+++ b/lib/composer
@@ -78,13 +78,12 @@ function install_composer_deps() {
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
             else
               if [[ $ext = 'oci8' ]]; then
-                install_oracle_client_extension
+                install_apt_libaio "${BUILD_DIR}" "$CACHE_DIR"
+                install_oracle_client_extension "${BUILD_DIR}"
               fi
-
               local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
-              install_pecl_extension $ext "$ext_version" "$CACHE_DIR" | indent
+              install_pecl_extension $ext "$ext_version" "${BUILD_DIR}" "$CACHE_DIR" | indent
             fi
-
             # TODO I don't think this instruction should be executed for all extensions
             fetch_package "$PHP_BASE_URL" "ext/$(php_api_version)/php-${ext}" "/app/vendor/php" 2>/dev/null || true | indent
         done

--- a/lib/composer
+++ b/lib/composer
@@ -77,6 +77,10 @@ function install_composer_deps() {
               fi
               fetch_package "$PHP_BASE_URL" "libsodium-${sodium_version}" "/app/vendor/libsodium" | indent
             else
+              if [[ $ext = 'oci8' ]]; then
+                install_oracle_client_extension
+              fi
+
               local ext_version=$(jq --raw-output ".require | .[\"ext-${ext}\"]" < "${BUILD_DIR}/composer.json")
               install_pecl_extension $ext "$ext_version" "$CACHE_DIR" | indent
             fi

--- a/lib/pecl
+++ b/lib/pecl
@@ -11,48 +11,6 @@ function enable_pecl_extension() {
   fi
 }
 
-function install_apt_libaio() {
-  # ----
-  # Install libaio to install oci8
-  echo "Installing libaio for oci8"
-
-  local build_dir="${1}"
-  local cache_dir="${2}"
-
-  echo "libaio1" > "${build_dir}/Aptfile"
-
-  apt_deps_buildpack_dir=$(mktemp apt_buildpack_XXXX)
-  rm "${apt_deps_buildpack_dir}"
-
-  readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
-  git clone --depth=1 "${apt_buildpack_url}" "${build_dir}/$apt_deps_buildpack_dir" > /dev/null
-
-  "${build_dir}/${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" > /dev/null
-}
-
-function install_oracle_client_extension() {
-  # ----
-  # Install oracle client
-  local build_dir="/app"
-  local oracle_install_dir="${build_dir}/vendor/oracle-client/"
-  mkdir -p "${oracle_install_dir}"
-
-  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
-  unzip -q oracleclient.zip -d "${oracle_install_dir}"
-  rm oracleclient.zip
-
-  export ORACLE_HOME="${oracle_install_dir}$(ls ${oracle_install_dir})"
-  export LD_LIBRARY_PATH="${ORACLE_HOME}/lib:${ORACLE_HOME}:${LD_LIBRARY_PATH}"
-
-  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
-  unzip -q oraclesdk.zip -d "${oracle_install_dir}"
-  rm oraclesdk.zip
-
-  local startup_script="${1}/.profile.d/oracle-client.sh"
-  echo "export ORACLE_HOME=${ORACLE_HOME}" >> "${startup_script}"
-  echo "export LD_LIBRARY_PATH=${ORACLE_HOME}/lib:${ORACLE_HOME}:\${LD_LIBRARY_PATH}" >> "${startup_script}"
-}
-
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"

--- a/lib/pecl
+++ b/lib/pecl
@@ -14,7 +14,7 @@ function enable_pecl_extension() {
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"
-  local cache_dir="${4}"
+  local cache_dir="${3}"
 
   if [[ $version = '*' ]]; then
     local version=$(curl --silent "https://pecl.php.net/rest/r/$extension_name/latest.txt")

--- a/lib/pecl
+++ b/lib/pecl
@@ -11,25 +11,52 @@ function enable_pecl_extension() {
   fi
 }
 
+function install_apt_libaio() {
+  # ----
+  # Install libaio to install oci8
+  echo "Installing libaio for oci8"
+
+  local build_dir="${1}"
+  local cache_dir="${2}"
+
+  echo "libaio1" > "${build_dir}/Aptfile"
+
+  apt_deps_buildpack_dir=$(mktemp apt_buildpack_XXXX)
+  rm "${apt_deps_buildpack_dir}"
+
+  readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
+  git clone --depth=1 "${apt_buildpack_url}" "${build_dir}/$apt_deps_buildpack_dir" > /dev/null
+
+  "${build_dir}/${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" > /dev/null
+}
+
 function install_oracle_client_extension() {
-  mkdir oracle/
+  # ----
+  # Install oracle client
+  local build_dir="/app"
+  local oracle_install_dir="${build_dir}/vendor/oracle-client/"
+  mkdir -p "${oracle_install_dir}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
-  unzip -q oracleclient.zip -d oracle/
+  unzip -q oracleclient.zip -d "${oracle_install_dir}"
   rm oracleclient.zip
 
-  export ORACLE_HOME=$(echo $(pwd)/oracle/instantclient_*) # TODO: Find a better way than * to catch the name of the client folder
-  export LD_LIBRARY_PATH=$ORACLE_HOME:$LD_LIBRARY_PATH
-  export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$LD_LIBRARY_PATH
+  export ORACLE_HOME="${oracle_install_dir}$(ls ${oracle_install_dir})"
+  export LD_LIBRARY_PATH="${ORACLE_HOME}/lib:${ORACLE_HOME}:${LD_LIBRARY_PATH}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
-  unzip -q oraclesdk.zip -d oracle/
+  unzip -q oraclesdk.zip -d "${oracle_install_dir}"
+  rm oraclesdk.zip
+
+  local startup_script="${1}/.profile.d/oracle-client.sh"
+  echo "export ORACLE_HOME=${ORACLE_HOME}" >> "${startup_script}"
+  echo "export LD_LIBRARY_PATH=${ORACLE_HOME}/lib:${ORACLE_HOME}:\${LD_LIBRARY_PATH}" >> "${startup_script}"
 }
 
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"
-  local cache_dir="${3}"
+  local cache_dir="${4}"
 
   if [[ $version = '*' ]]; then
     local version=$(curl --silent "https://pecl.php.net/rest/r/$extension_name/latest.txt")
@@ -54,17 +81,20 @@ function install_pecl_extension() {
   curl --silent --location "https://pecl.php.net/get/${extension_name}-${version}.tgz" | tar xz
 
   pushd ${extension_name}-${version} > /dev/null
-  /app/vendor/php/bin/phpize > /dev/null
+
+  /app/vendor/php/bin/phpize &> /dev/null
 
   local configure_extension_args_var_name="PHP_PECL_EXTENSION_CONFIGURE_ARGS_$extension_name"
   local configure_extension_args=$(printenv $configure_extension_args_var_name)
   local flags=$(echo $configure_extension_args | sed "s|\$BUILD_DIR|$build_dir|")
 
   if [[ $extension_name = 'oci8' ]]; then
-    flags="--with-oci8=instantclient,$ORACLE_HOME"
+    if [ -e "${3}/${apt_deps_buildpack_dir}/export" ]; then
+      source "${3}/${apt_deps_buildpack_dir}/export"
+    fi
+    flags="--with-oci8=instantclient,${ORACLE_HOME}"
   fi
 
-  echo "COMMAND ======= ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null"
   ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null
 
   make > /dev/null

--- a/lib/pecl
+++ b/lib/pecl
@@ -11,6 +11,21 @@ function enable_pecl_extension() {
   fi
 }
 
+function install_oracle_client_extension() {
+  mkdir oracle/
+
+  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
+  unzip -q oracleclient.zip -d oracle/
+  rm oracleclient.zip
+
+  export ORACLE_HOME=$(echo $(pwd)/oracle/instantclient_*) # TODO: Find a better way than * to catch the name of the client folder
+  export LD_LIBRARY_PATH=$ORACLE_HOME:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=$ORACLE_HOME/lib:$LD_LIBRARY_PATH
+
+  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
+  unzip -q oraclesdk.zip -d oracle/
+}
+
 function install_pecl_extension() {
   local extension_name="${1}"
   local version="${2}"
@@ -45,6 +60,11 @@ function install_pecl_extension() {
   local configure_extension_args=$(printenv $configure_extension_args_var_name)
   local flags=$(echo $configure_extension_args | sed "s|\$BUILD_DIR|$build_dir|")
 
+  if [[ $extension_name = 'oci8' ]]; then
+    flags="--with-oci8=instantclient,$ORACLE_HOME"
+  fi
+
+  echo "COMMAND ======= ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null"
   ./configure --with-php-config=/app/vendor/php/bin/php-config $flags > /dev/null
 
   make > /dev/null

--- a/lib/pecl_oci8
+++ b/lib/pecl_oci8
@@ -1,0 +1,48 @@
+function install_apt_libaio() {
+  # ----
+  # Install libaio to install oci8
+  local build_dir="${1}"
+  local cache_dir="${2}"
+  local env_dir="${3}"
+
+  echo "libaio1" > "${build_dir}/Aptfile"
+
+  apt_deps_buildpack_dir=$(mktemp apt_buildpack_XXXX)
+  rm "${apt_deps_buildpack_dir}"
+
+  readonly apt_buildpack_url="https://github.com/Scalingo/apt-buildpack.git"
+  git clone --quiet --depth=1 "${apt_buildpack_url}" "${build_dir}/$apt_deps_buildpack_dir" >/dev/null 2>/dev/null
+
+  "${build_dir}/${apt_deps_buildpack_dir}/bin/compile" "${build_dir}" "${cache_dir}" "${env_dir}" > /dev/null
+
+  # Source new libs for future buildpack (update of LD_LIBRARY_PATH)
+  export_file="${build_dir}/oci8_apt_export"
+  cp "${build_dir}/${apt_deps_buildpack_dir}/export" "${export_file}"
+
+  echo "${export_file}"
+}
+
+function install_oracle_client_extension() {
+  # ----
+  # Install oracle client
+  local build_dir="${1}"
+  local cache_dir="${2}"
+
+  local oracle_install_dir="${build_dir}/vendor/oracle-client/"
+  mkdir -p "${oracle_install_dir}"
+
+  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
+  unzip -q oracleclient.zip -d "${oracle_install_dir}"
+  rm oracleclient.zip
+
+  export ORACLE_HOME="${oracle_install_dir}$(ls ${oracle_install_dir})"
+  export LD_LIBRARY_PATH="${ORACLE_HOME}/lib:${ORACLE_HOME}:${LD_LIBRARY_PATH}"
+
+  curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
+  unzip -q oraclesdk.zip -d "${oracle_install_dir}"
+  rm oraclesdk.zip
+
+  local startup_script="${1}/.profile.d/oracle-client.sh"
+  echo "export ORACLE_HOME=${ORACLE_HOME}" >> "${startup_script}"
+  echo "export LD_LIBRARY_PATH=${ORACLE_HOME}/lib:${ORACLE_HOME}:\${LD_LIBRARY_PATH}" >> "${startup_script}"
+}


### PR DESCRIPTION
# What has been done:
- Installation of `libaio` via the APT builpack
- Installation of the oracle client in the vendor folder

# What's left to do:
- Cache oracle client download and APT buildpack clone
- Warning raised at build time for `libaio` should be fixed

Fix #290 