### PR TITLE
fix(php-ext-simplexml) Ignore case when checking embedded extensions since PHP module names are not consistent

### DIFF
--- a/lib/composer
+++ b/lib/composer
@@ -134,7 +134,7 @@ function install_composer_deps() {
 function is_embedded_extension() {
   local extension_name="${1}"
 
-  if php --modules | grep --quiet "${extension_name}" ; then
+  if php --modules | grep --quiet --ignore-case "${extension_name}" ; then
     echo "true"
   else
     echo "false"


### PR DESCRIPTION
Fixes #297

`simplexml` extension is displayed as `SimpleXML` in embedded modules list