### PR TITLE
Fix/php buildpack/293/rabbitmq-c-0.13.0

### DIFF
--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -67,7 +67,7 @@ build_librabbitmq() {
 
     cmake \
         -DCMAKE_INSTALL_PREFIX="${librabbitmq_dir}" \
-        -DBUILD_TESTS=OFF \
+        -DBUILD_TESTING=OFF \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_TOOLS=OFF \
         -DBUILD_TOOLS_DOCS=OFF \
@@ -161,7 +161,7 @@ librabbitmq_prefix="/app/vendor/php/lib/rabbitmq"
 # https://github.com/alanxz/rabbitmq-c/releases
 
 pkgname="librabbitmq-c"
-version="0.11.0"
+version="0.13.0"
 source_url="https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v%s.tar.gz"
 
 build_librabbitmq "${pkgname}" "${version}" "${source_url}" "${librabbitmq_prefix}"

--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -n "$DEBUG" ]; then
+if [ -n "$BUILDPACK_DEBUG" ]; then
     set -x
 fi
 

--- a/support/ext/amqp
+++ b/support/ext/amqp
@@ -65,19 +65,35 @@ build_librabbitmq() {
     download_archive "${archive_url}" \
         | tar xvz --strip-components=1
 
-    cmake \
-        -DCMAKE_INSTALL_PREFIX="${librabbitmq_dir}" \
-        -DBUILD_TESTING=OFF \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_TOOLS=OFF \
-        -DBUILD_TOOLS_DOCS=OFF \
-        -DBUILD_API_DOCS=OFF \
-        -DRUN_SYSTEM_TESTS=OFF \
-        -DBUILD_SHARED_LIBS=ON \
-        -DBUILD_STATIC_LIBS=OFF \
-        -Wno-dev \
-        || ( echo "Failed to build librabbitmq." \
-            && exit 1 )
+    if [ "${STACK}" = "scalingo-18" ]; then
+        cmake \
+            -DCMAKE_INSTALL_PREFIX="${librabbitmq_dir}" \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_TOOLS_DOCS=OFF \
+            -DBUILD_API_DOCS=OFF \
+            -DRUN_SYSTEM_TESTS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_STATIC_LIBS=OFF \
+            -Wno-dev \
+            || ( echo "Failed to build librabbitmq." \
+                && exit 1 )
+    else
+        cmake \
+            -DCMAKE_INSTALL_PREFIX="${librabbitmq_dir}" \
+            -DBUILD_TESTING=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_TOOLS=OFF \
+            -DBUILD_TOOLS_DOCS=OFF \
+            -DBUILD_API_DOCS=OFF \
+            -DRUN_SYSTEM_TESTS=OFF \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_STATIC_LIBS=OFF \
+            -Wno-dev \
+            || ( echo "Failed to build librabbitmq." \
+                && exit 1 )
+    fi
 
     cmake \
         --build . \
@@ -90,14 +106,16 @@ build_librabbitmq() {
 
     mkdir -p "${PREFIX}/lib"
 
-    # Move things that have been stored in `${prefix}/lib/x86_64-linux-gnu`
-    # to `${prefix}/lib` so that AMQP's `configure` finds them.
-    find "${librabbitmq_dir}/lib/x86_64-linux-gnu" \
-        -mindepth 1 \
-        -maxdepth 1 \
-        -exec mv --target-directory "${librabbitmq_dir}/lib/" -- {} \+
+    if [ "${STACK}" = "scalingo-18" ]; then
+        # Move things that have been stored in `${prefix}/lib/x86_64-linux-gnu`
+        # to `${prefix}/lib` so that AMQP's `configure` finds them.
+        find "${librabbitmq_dir}/lib/x86_64-linux-gnu" \
+            -mindepth 1 \
+            -maxdepth 1 \
+            -exec mv --target-directory "${librabbitmq_dir}/lib/" -- {} \+
 
-    rmdir "${librabbitmq_dir}/lib/x86_64-linux-gnu"
+        rmdir "${librabbitmq_dir}/lib/x86_64-linux-gnu"
+    fi
 
     # Copy library to `$PREFIX/lib` so it's included in the future package
     cp -ar "${librabbitmq_dir}" "${PREFIX}/lib/"
@@ -163,6 +181,10 @@ librabbitmq_prefix="/app/vendor/php/lib/rabbitmq"
 pkgname="librabbitmq-c"
 version="0.13.0"
 source_url="https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v%s.tar.gz"
+
+if [ "${STACK}" = "scalingo-18" ]; then
+    version="0.11.0"
+fi
 
 build_librabbitmq "${pkgname}" "${version}" "${source_url}" "${librabbitmq_prefix}"
 


### PR DESCRIPTION
Extension has been compiled with `rabbitmq-c-0.13.0` for:
- `scalingo-20`: PHP `7.4`, `8.0`, `8.1` and `8.2`
- `scalingo-22`: PHP `8.1` and `8.2`

It's not compatible with `scalingo-18` (`cmake` version requirement can't be honored), hence some specific code kept until `scalingo-18` is fully deprecated.

Files have been uploaded to ObjectStorage.

Fixes #293