### PR TITLE
fix(mongodb): update download URL

### DIFF
--- a/support/ext/mongodb
+++ b/support/ext/mongodb
@@ -8,8 +8,9 @@ fi
 
 # https://github.com/mongodb/mongo-php-driver/releases
 mongo_version="1.16.2"
+url="https://pecl.php.net/get/mongodb-{mongo_version}.tgz"
 
-curl --location "https://github.com/mongodb/mongo-php-driver/releases/download/${mongo_version}/mongodb-${mongo_version}.tgz" \
+curl --location "${url}" \
     | tar xzv
 
 cd mongodb-${mongo_version}


### PR DESCRIPTION
The usual `mongodb-$version.tgz` asset has not been uploaded on Github.
I suggest to change the URL to point to PECL, since the extension will always be available there.

This would allow to fix #344 