### PR TITLE
fix(datadog): Use the new Datadog installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,11 +352,10 @@ application on your dashboard.
 _Default: false_
 
 Enable support for [Datadog](https://www.datadoghq.com/), and specifically:
-- _Datadog APM_ with the [Datadog Tracer extension](https://github.com/DataDog/dd-trace-php/)
-- _Datadog Application Security_ with the [Datadog AppSec extension](https://github.com/DataDog/dd-appsec-php)
+- _Datadog APM (Application Performance Monitoring)_
+- _Datadog ASM (Application Security Management)_
 
 _Important:_
-- both extensions will be installed using the Datadog AppSec installer, which is still in beta
 - the Datadog agent has to be installed first ([see the documentation](https://doc.scalingo.com/platform/app/datadog))
 
 To enable Datadog support, set the `extra.paas.datadog` property to `true`:
@@ -365,18 +364,12 @@ To enable Datadog support, set the `extra.paas.datadog` property to `true`:
     "datadog": true
 ```
 
-This will automatically install and enable the latest available version of the Datadog Tracer. To disable the Tracer
-or install a specific version, use the `DATADOG_TRACER_VERSION` environment variable (`latest` by default).
+This will automatically install the latest available version of the Datadog Tracer and enable Datadog APM. To disable
+the tracer, set the `DATADOG_TRACER_VERSION` environment variable to `0` (`latest` by default). Note that disabling
+the tracer will disable APM and all other extensions (like ASM).
 
-Example:
-
-```
-DATADOG_TRACER_VERSION=0.71.0
-```
-
-The Datadog AppSec extension will be disabled by default. To install and enable the AppSec extension, set the
-`DATADOG_APPSEC_VERSION` environment variable to `latest` or any other valid version (`0` by default). Note that
-the AppSec extension requires the Tracer extension.
+The Datadog ASM (Application Security Management) extension will be disabled by default. To install and enable ASM,
+set the `DATADOG_APPSEC_VERSION` environment variable to `latest` (`0` by default).
 
 Example:
 

--- a/lib/datadog
+++ b/lib/datadog
@@ -4,15 +4,12 @@ function install_datadog() {
     local tracer_version="${1}"
     local appsec_version="${2}"
 
-    if [ "${tracer_version}" = "0" ] && [ "${appsec_version}" = "0" ]; then
+    if [ "${tracer_version}" = "0" ]; then
         echo >&2 "Skipping Datadog installation, as there is nothing to install."
     fi
 
-    local tracer_option
-    if [ "${tracer_version}" = "0" ]; then tracer_option="--no-tracer"; else tracer_option="--version=${tracer_version}"; fi
-
     local appsec_option
-    if [ "${appsec_version}" = "0" ]; then appsec_option="--no-appsec"; else appsec_option="--version=${appsec_version}"; fi
+    if [ "${appsec_version}" = "0" ]; then appsec_option=""; else appsec_option="--enable-appsec"; fi
 
     local install_dir="${BUILD_DIR}/vendor/datadog"
     local cwd=$(pwd)
@@ -20,15 +17,14 @@ function install_datadog() {
 
     cd "${tempdir}"
 
-    # the AppSec extension is in public beta right now, and the URL of the installer might change in the future
-    curl --silent -L "https://raw.githubusercontent.com/DataDog/dd-appsec-php/installer/dd-library-php-setup.php" > dd-library-php-setup.php
+    curl --silent -L "https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php" > datadog-setup.php
     mkdir -p ${install_dir}
-    php dd-library-php-setup.php ${tracer_option} ${appsec_option} --php-bin=all --install-dir=${install_dir}
+    php datadog-setup.php --php-bin=all ${appsec_option} --install-dir=${install_dir}
 
     [ -f '/app/vendor/php/etc/conf.d/98-ddtrace.ini' ] && sed -i "s@$BUILD_DIR@/app@g" /app/vendor/php/etc/conf.d/98-ddtrace.ini
     [ -f '/app/vendor/php/etc/conf.d/98-ddappsec.ini' ] && sed -i "s@$BUILD_DIR@/app@g" /app/vendor/php/etc/conf.d/98-ddappsec.ini
 
-    if [ "${appsec_option}" != "--no-appsec" ]; then
+    if [ "${appsec_option}" != "" ]; then
         mkdir -p "${BUILD_DIR}/.profile.d"
         local startup_script="${BUILD_DIR}/.profile.d/datadog.sh"
         # startup_script should have been created by the Datadog Agent buildpack, but let's make sure it's here anyway


### PR DESCRIPTION
fixes https://github.com/Scalingo/php-buildpack/issues/350

This pull request changes the way Datadog extensions are installed:
- stop using the old install script that was in public beta (and did not officially support PHP 8.2)
- use the new install script provided by Datadog
- avoid failures due to Github API rate limits, as reported in https://github.com/Scalingo/php-buildpack/issues/350
- stop documenting how to request specific versions of the extensions: it has never worked, and the new install script does not support this feature.

I don't know if other people are using this feature, so I did my best to avoid a breaking change and kept the environment variables the same as before.

I have been testing this branch on our production project and it works just fine:

```
[LOG] -----> Datadog usage detected, installing PHP extensions
[LOG] Searching for available php binaries, this operation might take a while.
[LOG] Downloading installable archive from https://github.com/DataDog/dd-trace-php/releases/download/0.91.1/dd-library-php-0.91.1-x86_64-linux-gnu.tar.gz.
[LOG] This operation might take a while.
[LOG] ...................
[LOG] Download completed
[LOG] Installed required source files to '/build/177d6fd0-a4ac-4c78-8120-9e1a056a91e0/vendor/datadog/dd-library/0.91.1'
[LOG] Installing to binary: php (/app/vendor/php/bin/php)
[LOG] Copied '/tmp/dd-install/dd-library-php/trace/ext/20220829/ddtrace.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/ddtrace.so'
[LOG] Copied '/tmp/dd-install/dd-library-php/profiling/ext/20220829/datadog-profiling.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/datadog-profiling.so'
[LOG] Copied '/tmp/dd-install/dd-library-php/appsec/ext/20220829/ddappsec.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/ddappsec.so'
[LOG] Created INI file '/app/vendor/php/etc/conf.d/98-ddtrace.ini'
[LOG] Installation to 'php (/app/vendor/php/bin/php)' was successful
[LOG] Installing to binary: php-fpm (/app/vendor/php/sbin/php-fpm)
[LOG] Copied '/tmp/dd-install/dd-library-php/trace/ext/20220829/ddtrace.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/ddtrace.so'
[LOG] Copied '/tmp/dd-install/dd-library-php/profiling/ext/20220829/datadog-profiling.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/datadog-profiling.so'
[LOG] Copied '/tmp/dd-install/dd-library-php/appsec/ext/20220829/ddappsec.so' to '/app/vendor/php/lib/php/extensions/no-debug-non-zts-20220829/ddappsec.so'
[LOG] Updating existing INI file '/app/vendor/php/etc/conf.d/98-ddtrace.ini'
[LOG] Installation to 'php-fpm (/app/vendor/php/sbin/php-fpm)' was successful
[LOG] --------------------------------------------------
[LOG] SUCCESS
```