### PR TITLE
chore(sodium): upgrade to 1.0.19

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -35,7 +35,7 @@ sodium_php72_php73_version="1.0.7"
 libmemcached_version="1.0.18"
 gmp_version="6.2.1"
 tidy_version="5.8.0"
-sodium_version="1.0.18"
+sodium_version="1.0.19"
 coreutils_version="8.32"
 webp_version="${webp_version:-1.2.4}" # Can be found here: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html
 # Mandatory for multibytes strings starting with PHP 7.4

--- a/support/get_sodium
+++ b/support/get_sodium
@@ -7,33 +7,40 @@ source "$basedir/lib/utils"
 source "$basedir/lib/swift"
 
 function build_libsodium() {
-  version=$1
-  url_prefix=$2
+  version="${1}"
+  url_prefix="${2}"
 
-  tempdir=$(mktmpdir libsodium)
-  pushd $tempdir
+  rm --recursive --force /app/vendor/libsodium
+  mkdir --parents /app/vendor/libsodium
+
+  tempdir="$( mktmpdir libsodium )"
+  pushd "${tempdir}"
 
   echo "-----> Downloading Sodium v${version}"
-  curl -LO "https://download.libsodium.org/libsodium/$url_prefix/libsodium-${version}.tar.gz"
+  curl --location --remote-name "https://download.libsodium.org/libsodium/${url_prefix}/libsodium-${version}.tar.gz"
 
-  tar xvf "libsodium-${version}.tar.gz"
-  cd "libsodium-${version}"
-  rm -r /app/vendor/libsodium
-  mkdir -p /app/vendor/libsodium
+  mkdir "libsodium"
+  pushd "libsodium"
+
+  tar --extract --verbose --strip-components=1 \
+      --file="../libsodium-${version}.tar.gz"
 
   ./configure --prefix=/app/vendor/libsodium
   make
   make install
 
-  cd $tempdir
-  mkdir package
-  cd package
-  tar -C /app/vendor/libsodium -czvf "libsodium-${version}.tgz" .
-  cd ..
+  popd
 
-  swift_upload package/libsodium-${version}.tgz
+  mkdir "package"
+  pushd "package"
 
-  "$basedir/package-checksum" "libsodium-${version}"
+  tar --directory="/app/vendor/libsodium" --create --gzip --verbose \
+      --file="libsodium-${version}.tgz" .
+
+  popd
+
+  swift_upload "package/libsodium-${version}.tgz"
+  "${basedir}/package-checksum" "libsodium-${version}"
 
   popd
 }


### PR DESCRIPTION
Packages have been generated and uploaded on Object Storage for both `scalingo-20` and `scalingo-22`.

Fixes #352 