### PR TITLE
chore(webp): upgrade to 1.3.2

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -37,7 +37,7 @@ gmp_version="6.2.1"
 tidy_version="5.8.0"
 sodium_version="1.0.18"
 coreutils_version="8.32"
-webp_version="${webp_version:-1.2.4}" # Can be found here: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html
+webp_version="${webp_version:-1.3.2}" # Can be found here: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html
 # Mandatory for multibytes strings starting with PHP 7.4
 libonig_version="${libonig_version:-6.9.8}"
 # From https://zlib.net/


### PR DESCRIPTION
Packages have been generated and uploaded on Object Storage for `scalingo-20`, `scalingo-22`, `scalingo-20-minimal` and `scalingo-22-minimal`.

Fixes https://github.com/Scalingo/php-buildpack/issues/354