### PR TITLE
feat(tests): improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-STACK := "scalingo-20"
-IMAGE := scalingo/$(STACK):latest
-BASH_COMMAND := /bin/bash
+STACK = "scalingo-20"
+BASH_COMMAND = /bin/bash
 
-.DEFAULT := test
+.DEFAULT = all
 
-test: BASH_COMMAND := test/run
-test: docker
+all: test
+test: test20 test22
 
-docker:
+test22: STACK = "scalingo-22"
+
+test20 test22: BASH_COMMAND = test/run
+test20 test22: IMAGE = "scalingo/$(STACK):latest"
+test20 test22:
 	@echo "Running tests in Docker using $(IMAGE)"
 	@docker run --pull always --mount type=bind,src=$(PWD),dst=/buildpack,readonly --workdir /buildpack --rm --interactive --tty --env "GITLAB_TOKEN=$(GITLAB_TOKEN)" --env "GITHUB_TOKEN=$(GITHUB_TOKEN)" --env "STACK=$(STACK)" $(IMAGE) bash -c "$(BASH_COMMAND)"
-

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-STACK = "scalingo-20"
-BASH_COMMAND = /bin/bash
+STACK := "scalingo-20"
+BASH_COMMAND := /bin/bash
 
-.DEFAULT = all
+.DEFAULT := all
 
 all: test
 test: test20 test22
 
-test22: STACK = "scalingo-22"
+test22: STACK := "scalingo-22"
 
-test20 test22: BASH_COMMAND = test/run
-test20 test22: IMAGE = "scalingo/$(STACK):latest"
+test20 test22: BASH_COMMAND := test/run
+test20 test22: IMAGE := "scalingo/$(STACK):latest"
 test20 test22:
 	@echo "Running tests in Docker using $(IMAGE)"
 	@docker run --pull always --mount type=bind,src=$(PWD),dst=/buildpack,readonly --workdir /buildpack --rm --interactive --tty --env "GITLAB_TOKEN=$(GITLAB_TOKEN)" --env "GITHUB_TOKEN=$(GITHUB_TOKEN)" --env "STACK=$(STACK)" $(IMAGE) bash -c "$(BASH_COMMAND)"


### PR DESCRIPTION
Add ability to run:
- `make test20` to run tests on the scalingo-20 stack.
- `make test22` to run tests on the scalingo-22 stack.
- `make all`: to run tests on both scalingo-20 and scalingo-22 stacks.
- `make` and `make test` default to `make all`.