### PR TITLE
fix(php-buildpack): composer prevails over env

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -73,16 +73,26 @@ function best_nginx_version() {
 
 function best_php_version() {
   local require_php=""
-  if [ -f "$BUILD_DIR/composer.json" ] ; then
+
+  # First check if we have something in composer.json
+  # If so, this is the value we want. It must always prevail:
+  if [ -f "${BUILD_DIR}/composer.json" ] ; then
     for key in ".require.php" ".config.platform.php" ".extra.${composer_extra_key}.engines.php" ; do
-      require_php=$(jq --raw-output "${key} // \"\"" < "$BUILD_DIR/composer.json")
+      require_php="$( jq --raw-output "${key} // \"\"" < "${BUILD_DIR}/composer.json" )"
       [ -n "${require_php}" ] && break
     done
   fi
-  if [ -n "$PHP_VERSION" ] ; then
-    require_php="$PHP_VERSION"
+
+  # If nothing is specified in composer.json
+  # Or if this is a Classic app, we should check PHP_VERSION:
+  if [ -z "${require_php}" ] && [ -n "${PHP_VERSION}" ] ; then
+    require_php="${PHP_VERSION}"
   fi
-  [ -z "${require_php}" ] && require_php="$DEFAULT_PHP"
+
+  if [ -z "${require_php}" ]; then
+    require_php="${DEFAULT_PHP}"
+  fi
+
   curl --fail --location --silent "${SEMVER_SERVER}/php-${STACK}/resolve/${require_php}"
 }
 

--- a/test/helpers
+++ b/test/helpers
@@ -2,7 +2,7 @@
 
 ### Helpers functions
 
-test::helpers::test_deploy() {
+test::helpers::deploy() {
     # Deploys a PHP app step by step and tests that everything is working as
     # expected.
     # To do so, this function runs the buildpack scripts and mimicks the
@@ -24,17 +24,17 @@ test::helpers::test_deploy() {
     local version="${2}"
 
     # Test that bin/detect works as expected:
-    test::helpers::test_detect "${detect_expectation}"
+    test::helpers::detect "${detect_expectation}"
 
     # Test that bin/compile works as expected:
-    test::helpers::test_compile "${version}"
+    test::helpers::compile "${version}"
 
     # Test that all default PHP modules are available:
-    test::helpers::test_default_modules
+    test::helpers::default_modules
 }
 
 test::helpers::detect() {
-    # Runs the `bin/detect`script of the buildpack and then:
+    # Runs the `bin/detect` script of the buildpack and then:
     # - Asserts that it succeeded
     # - Asserts that the output equals what's expected.
     #

--- a/test/helpers
+++ b/test/helpers
@@ -89,7 +89,7 @@ test::helpers::compile() {
     test::utils::assertCapturedStartswith "PHP ${version}"
 }
 
-test::helpers::test_default_modules() {
+test::helpers::default_modules() {
     # Test that all default PHP modules are available.
     #
     # Globals:

--- a/test/helpers
+++ b/test/helpers
@@ -33,7 +33,7 @@ test::helpers::test_deploy() {
     test::helpers::test_default_modules
 }
 
-test::helpers::test_detect() {
+test::helpers::detect() {
     # Runs the `bin/detect`script of the buildpack and then:
     # - Asserts that it succeeded
     # - Asserts that the output equals what's expected.

--- a/test/helpers
+++ b/test/helpers
@@ -51,7 +51,7 @@ test::helpers::detect() {
     test::utils::assertCapturedEquals "${expected_output}"
 }
 
-test::helpers::test_compile() {
+test::helpers::compile() {
     # Runs the `bin/compile` script of the buildpack and then:
     # - Asserts that is succeeded
     # - Asserts that the version of installed PHP is the one expected

--- a/test/helpers
+++ b/test/helpers
@@ -14,17 +14,50 @@ test::helpers::test_deploy() {
     #   default_modules
     #
     # Arguments:
-    #   $1 > $fixture_name: Name of the fixture to deploy.
-    #      The fixture sets the deployment conditions.
-    #      In fact, this is the name of a directory that must exist in
-    #      `BUILDPACK_DIR/test/fixtures/` and that contains the fixture code.
-    #      See `test::utils::setupFixture` for more details.
+    #   $1 > $detect_expectation
+    #      See `test::helpers::test_detect`.
     #
-    #   $2 > $detect_expectation: Expected output of `bin/compile`.
-    #      The value of this variable is compared to the actual output of the
-    #      `bin/detect` script (and should match).
+    #   $2 > $version
+    #      See `test::helpers::test_compile`.
+
+    local detect_expectation="${1}"
+    local version="${2}"
+
+    # Test that bin/detect works as expected:
+    test::helpers::test_detect "${detect_expectation}"
+
+    # Test that bin/compile works as expected:
+    test::helpers::test_compile "${version}"
+
+    # Test that all default PHP modules are available:
+    test::helpers::test_default_modules
+}
+
+test::helpers::test_detect() {
+    # Runs the `bin/detect`script of the buildpack and then:
+    # - Asserts that it succeeded
+    # - Asserts that the output equals what's expected.
     #
-    #   $3 > $version: Expected version of PHP.
+    # Arguments:
+    #   $1 > $expected_output
+    #      The value of this variable must equal the actual output of the
+    #      `bin/detect` script for the assertion to pass.
+
+    local expected_output="${1}"
+
+    test::utils::detect
+
+    test::utils::assertCapturedSuccess
+    test::utils::assertCapturedEquals "${expected_output}"
+}
+
+test::helpers::test_compile() {
+    # Runs the `bin/compile` script of the buildpack and then:
+    # - Asserts that is succeeded
+    # - Asserts that the version of installed PHP is the one expected
+    #
+    # Arguments:
+    #   $1 > $version: Expected version of PHP.
     #      The value of this variable is compared to the version of PHP
     #      that has actually been installed by the buildpack.
     #      PHP version numbers follow the semver standard (i.e.
@@ -39,19 +72,8 @@ test::helpers::test_deploy() {
     #      To test a full version, please add a trailing space, i.e. `8.1.15␣`,
     #      so that `8.1.156` doesn't make the test pass.
 
-    local fixture_name="${1}"
-    local detect_expectation="${2}"
-    local version="${3}"
+    local version="${1}"
 
-    # Setup the fixture:
-    test::utils::setupFixture "${fixture_name}"
-
-    # Test that bin/detect works as expected:
-    test::utils::detect
-    test::utils::assertCapturedSuccess
-    test::utils::assertCapturedEquals "${detect_expectation}"
-
-    # Test that bin/compile works as expected:
     test::utils::compile
     # We can't use assertCapturedSuccess here:
     # With an empty composer.json file, composer will use stderr to warn us
@@ -62,12 +84,20 @@ test::helpers::test_deploy() {
     # Switch environment:
     test::helpers::enter_prod
 
-    # Test that PHP has the awaited version:
+    # Test that PHP has the expected version:
     test::helpers::get_php_version
     test::utils::assertCapturedStartswith "PHP ${version}"
+}
 
-    # Test that all default PHP modules are available:
+test::helpers::test_default_modules() {
+    # Test that all default PHP modules are available.
+    #
+    # Globals:
+    #   default_modules
+
+    # List all installed modules in STD_OUT:
     test::helpers::list_php_modules
+
     for module in "${default_modules[@]}"; do
         test::utils::assertFileContains "${module}" "${STD_OUT}"
     done

--- a/test/tests
+++ b/test/tests
@@ -145,7 +145,7 @@ test::composer::php_version_lower_than_env() {
     test::helpers::test_compile "8.3."
 }
 
-test::composer::over_greater_env() {
+test::composer::php_version_greater_than_env() {
     # Test a deployment of a PHP app using Composer
     # Where PHP version requirement is specified in both composer.json
     # and PHP_VERSION.

--- a/test/tests
+++ b/test/tests
@@ -120,7 +120,7 @@ test::composer::php83() {
     test::helpers::test_deploy "PHP (composer.json)" "8.3."
 }
 
-test::composer::over_defaults() {
+test::composer::php_version_defaults() {
     # Test a deployment of a PHP app using Composer
     # Where the PHP version requirement is only specified in PHP_VERSION.
 

--- a/test/tests
+++ b/test/tests
@@ -20,7 +20,8 @@ test::classic::defaults() {
     # Test a deployment of a classic app (not using Composer)
     # With default settings
 
-    test::helpers::test_deploy "classic_default" "PHP (classic)" "8.1."
+    test::utils::setupFixture "classic_default"
+    test::helpers::test_deploy "PHP (classic)" "8.1."
 }
 
 test::classic::php80() {
@@ -36,7 +37,8 @@ test::classic::php80() {
         startSkipping
     fi
 
-    test::helpers::test_deploy "classic_default" "PHP (classic)" "8.0."
+    test::utils::setupFixture "classic_default"
+    test::helpers::test_deploy "PHP (classic)" "8.0."
 }
 
 test::classic::php81() {
@@ -46,7 +48,8 @@ test::classic::php81() {
     PHP_VERSION="8.1"
     export PHP_VERSION
 
-    test::helpers::test_deploy "classic_default" "PHP (classic)" "8.1."
+    test::utils::setupFixture "classic_default"
+    test::helpers::test_deploy "PHP (classic)" "8.1."
 }
 
 test::classic::php82() {
@@ -56,7 +59,8 @@ test::classic::php82() {
     PHP_VERSION="8.2"
     export PHP_VERSION
 
-    test::helpers::test_deploy "classic_default" "PHP (classic)" "8.2."
+    test::utils::setupFixture "classic_default"
+    test::helpers::test_deploy "PHP (classic)" "8.2."
 }
 
 test::classic::php83() {
@@ -66,14 +70,16 @@ test::classic::php83() {
     PHP_VERSION="8.3"
     export PHP_VERSION
 
-    test::helpers::test_deploy "classic_default" "PHP (classic)" "8.3."
+    test::utils::setupFixture "classic_default"
+    test::helpers::test_deploy "PHP (classic)" "8.3."
 }
 
 test::composer::defaults() {
     # Test a deployment of a PHP app using Composer
     # With default settings
 
-    test::helpers::test_deploy "composer_default" "PHP (composer.json)" "8.1."
+    test::utils::setupFixture "composer_default"
+    test::helpers::test_deploy "PHP (composer.json)" "8.1."
 }
 
 test::composer::php80() {
@@ -86,28 +92,71 @@ test::composer::php80() {
         startSkipping
     fi
 
-    test::helpers::test_deploy "composer_php80" "PHP (composer.json)" "8.0."
+    test::utils::setupFixture "composer_php80"
+    test::helpers::test_deploy "PHP (composer.json)" "8.0."
 }
 
 test::composer::php81() {
     # Test a deployment of a PHP app using Composer
     # Specifying we want PHP 8.1.x in composer.json
 
-    test::helpers::test_deploy "composer_php81" "PHP (composer.json)" "8.1."
+    test::utils::setupFixture "composer_php81"
+    test::helpers::test_deploy "PHP (composer.json)" "8.1."
 }
 
 test::composer::php82() {
     # Test a deployment of a PHP app using Composer
     # Specifying we want PHP 8.2.x in composer.json
 
-    test::helpers::test_deploy "composer_php82" "PHP (composer.json)" "8.2."
+    test::utils::setupFixture "composer_php82"
+    test::helpers::test_deploy "PHP (composer.json)" "8.2."
 }
 
 test::composer::php83() {
     # Test a deployment of a PHP app using Composer
     # Specifying we want PHP 8.3.x in composer.json
 
-    test::helpers::test_deploy "composer_php83" "PHP (composer.json)" "8.3."
+    test::utils::setupFixture "composer_php83"
+    test::helpers::test_deploy "PHP (composer.json)" "8.3."
+}
+
+test::composer::over_defaults() {
+    # Test a deployment of a PHP app using Composer
+    # Where the PHP version requirement is only specified in PHP_VERSION.
+
+    PHP_VERSION="8.3"
+    export PHP_VERSION
+
+    test::utils::setupFixture "composer_default"
+    test::helpers::test_compile "8.3."
+}
+
+test::composer::over_lower_env() {
+    # Test a deployment of a PHP app using Composer
+    # Where the PHP version requirement is specified in both composer.json
+    # and PHP_VERSION.
+    # And where the version specified in composer.json is greater than the one
+    # specified in PHP_VERSION.
+
+    PHP_VERSION="8.2"
+    export PHP_VERSION
+
+    test::utils::setupFixture "composer_php83"
+    test::helpers::test_compile "8.3."
+}
+
+test::composer::over_greater_env() {
+    # Test a deployment of a PHP app using Composer
+    # Where PHP version requirement is specified in both composer.json
+    # and PHP_VERSION.
+    # And where the version specified in composer.json is lower than the one
+    # specified in PHP_VERSION.
+
+    PHP_VERSION="8.3"
+    export PHP_VERSION
+
+    test::utils::setupFixture "composer_php82"
+    test::helpers::test_compile "8.2."
 }
 
 
@@ -124,3 +173,8 @@ suite_addTest test::composer::php80
 suite_addTest test::composer::php81
 suite_addTest test::composer::php82
 suite_addTest test::composer::php83
+
+suite_addTest test::composer::over_defaults
+suite_addTest test::composer::over_lower_env
+suite_addTest test::composer::over_greater_env
+

--- a/test/tests
+++ b/test/tests
@@ -21,7 +21,7 @@ test::classic::defaults() {
     # With default settings
 
     test::utils::setupFixture "classic_default"
-    test::helpers::test_deploy "PHP (classic)" "8.1."
+    test::helpers::deploy "PHP (classic)" "8.1."
 }
 
 test::classic::php80() {
@@ -38,7 +38,7 @@ test::classic::php80() {
     fi
 
     test::utils::setupFixture "classic_default"
-    test::helpers::test_deploy "PHP (classic)" "8.0."
+    test::helpers::deploy "PHP (classic)" "8.0."
 }
 
 test::classic::php81() {
@@ -49,7 +49,7 @@ test::classic::php81() {
     export PHP_VERSION
 
     test::utils::setupFixture "classic_default"
-    test::helpers::test_deploy "PHP (classic)" "8.1."
+    test::helpers::deploy "PHP (classic)" "8.1."
 }
 
 test::classic::php82() {
@@ -60,7 +60,7 @@ test::classic::php82() {
     export PHP_VERSION
 
     test::utils::setupFixture "classic_default"
-    test::helpers::test_deploy "PHP (classic)" "8.2."
+    test::helpers::deploy "PHP (classic)" "8.2."
 }
 
 test::classic::php83() {
@@ -71,7 +71,7 @@ test::classic::php83() {
     export PHP_VERSION
 
     test::utils::setupFixture "classic_default"
-    test::helpers::test_deploy "PHP (classic)" "8.3."
+    test::helpers::deploy "PHP (classic)" "8.3."
 }
 
 test::composer::defaults() {
@@ -79,7 +79,7 @@ test::composer::defaults() {
     # With default settings
 
     test::utils::setupFixture "composer_default"
-    test::helpers::test_deploy "PHP (composer.json)" "8.1."
+    test::helpers::deploy "PHP (composer.json)" "8.1."
 }
 
 test::composer::php80() {
@@ -93,7 +93,7 @@ test::composer::php80() {
     fi
 
     test::utils::setupFixture "composer_php80"
-    test::helpers::test_deploy "PHP (composer.json)" "8.0."
+    test::helpers::deploy "PHP (composer.json)" "8.0."
 }
 
 test::composer::php81() {
@@ -101,7 +101,7 @@ test::composer::php81() {
     # Specifying we want PHP 8.1.x in composer.json
 
     test::utils::setupFixture "composer_php81"
-    test::helpers::test_deploy "PHP (composer.json)" "8.1."
+    test::helpers::deploy "PHP (composer.json)" "8.1."
 }
 
 test::composer::php82() {
@@ -109,7 +109,7 @@ test::composer::php82() {
     # Specifying we want PHP 8.2.x in composer.json
 
     test::utils::setupFixture "composer_php82"
-    test::helpers::test_deploy "PHP (composer.json)" "8.2."
+    test::helpers::deploy "PHP (composer.json)" "8.2."
 }
 
 test::composer::php83() {
@@ -117,7 +117,7 @@ test::composer::php83() {
     # Specifying we want PHP 8.3.x in composer.json
 
     test::utils::setupFixture "composer_php83"
-    test::helpers::test_deploy "PHP (composer.json)" "8.3."
+    test::helpers::deploy "PHP (composer.json)" "8.3."
 }
 
 test::composer::php_version_defaults() {
@@ -128,10 +128,10 @@ test::composer::php_version_defaults() {
     export PHP_VERSION
 
     test::utils::setupFixture "composer_default"
-    test::helpers::test_compile "8.3."
+    test::helpers::compile "8.3."
 }
 
-test::composer::php_version_lower_than_env() {
+test::composer::php_version_greater_than_env() {
     # Test a deployment of a PHP app using Composer
     # Where the PHP version requirement is specified in both composer.json
     # and PHP_VERSION.
@@ -142,10 +142,10 @@ test::composer::php_version_lower_than_env() {
     export PHP_VERSION
 
     test::utils::setupFixture "composer_php83"
-    test::helpers::test_compile "8.3."
+    test::helpers::compile "8.3."
 }
 
-test::composer::php_version_greater_than_env() {
+test::composer::php_version_lower_than_env() {
     # Test a deployment of a PHP app using Composer
     # Where PHP version requirement is specified in both composer.json
     # and PHP_VERSION.
@@ -156,7 +156,7 @@ test::composer::php_version_greater_than_env() {
     export PHP_VERSION
 
     test::utils::setupFixture "composer_php82"
-    test::helpers::test_compile "8.2."
+    test::helpers::compile "8.2."
 }
 
 
@@ -174,7 +174,7 @@ suite_addTest test::composer::php81
 suite_addTest test::composer::php82
 suite_addTest test::composer::php83
 
-suite_addTest test::composer::over_defaults
-suite_addTest test::composer::over_lower_env
-suite_addTest test::composer::over_greater_env
+suite_addTest test::composer::php_version_defaults
+suite_addTest test::composer::php_version_greater_than_env
+suite_addTest test::composer::php_version_lower_than_env
 

--- a/test/tests
+++ b/test/tests
@@ -131,7 +131,7 @@ test::composer::php_version_defaults() {
     test::helpers::test_compile "8.3."
 }
 
-test::composer::over_lower_env() {
+test::composer::php_version_lower_than_env() {
     # Test a deployment of a PHP app using Composer
     # Where the PHP version requirement is specified in both composer.json
     # and PHP_VERSION.


### PR DESCRIPTION
Make sure choosing a PHP version with Composer always prevails over setting `$PHP_VERSION` env var.

Also split some `test::helpers` into several functions for better usage.

I'm not that inspired for the `test::composer::over_*` functions naming :disappointed: so feel free to suggest something else!

Fix #404 