### PR TITLE
fix: fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Trigger CI workflow when a push event occurs on the master branch.
Related to the discussion here in #364.

Fix #364