### PR TITLE
fix(oci8): unzip should replace existing file

### DIFF
--- a/lib/composer
+++ b/lib/composer
@@ -1,5 +1,29 @@
 # vim:set ft=sh:
 
+function get_php_version() {
+    # Prints out the PHP version (major.minor)
+
+    php -v \
+        | head -n 1 \
+        | cut -d " " -f 2 \
+        | cut -f 1-2 -d "."
+}
+
+function version_is_ge() {
+    # Checks if the given version is greater or equal than the one required
+    # $1: version to check
+    # $2: required version
+
+    local rc=1
+
+    if { echo "${1}"; echo "${2}"; } | sort --reverse --version-sort --check 2> /dev/null
+    then
+        rc=0
+    fi
+
+    return "${rc}"
+}
+
 function check_composer_syntax() {
   local target="$1"
 
@@ -82,6 +106,23 @@ function install_composer_deps() {
             # Then compare:
             if [ "${ext_lower}" = "zend-opcache" ]; then
                 ext="zend opcache"
+            fi
+
+
+            # The oci8 extension is only available for PHP 8.2 and above:
+
+            if [ "$ext" = "oci8" ] ; then
+              local php_version="$( get_php_version )"
+
+              if ! version_is_ge "${php_version}" "8.2"; then
+                echo "\
+!       The oci8 PHP extension requires PHP 8.2 or above to run.
+!       Please make sure to specify this requirement in your composer.json file.
+!       For further help, please see https://doc.scalingo.com/languages/php/start#select-a-version
+!       Aborting.
+" >&2
+                exit 1
+              fi
             fi
 
             is_embedded="$(is_embedded_extension ${ext})"

--- a/lib/pecl_oci8
+++ b/lib/pecl_oci8
@@ -17,7 +17,6 @@ function install_oracle_client_extension() {
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
   unzip -o -q oraclesdk.zip -d "${oracle_install_dir}"
   rm oraclesdk.zip
-  curl -s "https://download.oracle.com/otn_software/linux/instantclient/2340000/instantclient-basic-linux.x64-23.4.0.24.05.zip"
 
   readonly startup_script="${1}/.profile.d/oracle-client.sh"
   # Replacing build_dir by /app, final location of the image data.

--- a/lib/pecl_oci8
+++ b/lib/pecl_oci8
@@ -8,15 +8,16 @@ function install_oracle_client_extension() {
   mkdir -p "${oracle_install_dir}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
-  unzip -q oracleclient.zip -d "${oracle_install_dir}"
+  unzip -o -q oracleclient.zip -d "${oracle_install_dir}"
   rm oracleclient.zip
 
   export ORACLE_HOME="${oracle_install_dir}$(ls ${oracle_install_dir})"
   export LD_LIBRARY_PATH="${ORACLE_HOME}/lib:${ORACLE_HOME}:${LD_LIBRARY_PATH}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
-  unzip -q oraclesdk.zip -d "${oracle_install_dir}"
+  unzip -o -q oraclesdk.zip -d "${oracle_install_dir}"
   rm oraclesdk.zip
+  curl -s "https://download.oracle.com/otn_software/linux/instantclient/2340000/instantclient-basic-linux.x64-23.4.0.24.05.zip"
 
   readonly startup_script="${1}/.profile.d/oracle-client.sh"
   # Replacing build_dir by /app, final location of the image data.

--- a/lib/pecl_oci8
+++ b/lib/pecl_oci8
@@ -8,14 +8,16 @@ function install_oracle_client_extension() {
   mkdir -p "${oracle_install_dir}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip --output oracleclient.zip
-  unzip -o -q oracleclient.zip -d "${oracle_install_dir}"
+  # We are only interested in the "instantclient_..." directory:
+  unzip -o -q oracleclient.zip "instantclient*" -d "${oracle_install_dir}"
   rm oracleclient.zip
 
   export ORACLE_HOME="${oracle_install_dir}$(ls ${oracle_install_dir})"
   export LD_LIBRARY_PATH="${ORACLE_HOME}/lib:${ORACLE_HOME}:${LD_LIBRARY_PATH}"
 
   curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip
-  unzip -o -q oraclesdk.zip -d "${oracle_install_dir}"
+  # We are only interested in the "instantclient_..." directory:
+  unzip -o -q oraclesdk.zip "instantclient*" -d "${oracle_install_dir}"
   rm oraclesdk.zip
 
   readonly startup_script="${1}/.profile.d/oracle-client.sh"


### PR DESCRIPTION
This PR fixes the deployment issue:
```sh
[LOG] + curl --silent https://download.oracle.com/otn_software/linux/instantclient/instantclient-sdk-linuxx64.zip --output oraclesdk.zip                                                                                                       
[LOG] + unzip -q oraclesdk.zip -d /build/036626aa-77f8-4ace-8f20-29077f408b28/vendor/oracle-client/                                                                                                                                            
[LOG] replace /build/036626aa-77f8-4ace-8f20-29077f408b28/vendor/oracle-client/META-INF/MANIFEST.MF? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL                                                                                               
[LOG] (EOF or read error, treating as "[N]one" ...)                                                                                                                                                                                            
[LOG] !     An error occurred during buildpack compilation                                                                                                                                                                                     
```

Fix #429 