### PR TITLE
fix(composer): match exactly the extension name

### DIFF
--- a/lib/composer
+++ b/lib/composer
@@ -204,7 +204,7 @@ function is_embedded_extension() {
   [ ${rc} -ne 0 ] && \
     error "error while trying to identify if ${extension_name} is embedded in runtime: ${php_modules} (${rc})."
 
-  if echo "${php_modules}" | grep --quiet --ignore-case "${extension_name}" ; then
+  if echo "${php_modules}" | grep --quiet --extended-regexp --ignore-case "^${extension_name}$" ; then
     echo "true"
   else
     echo "false"


### PR DESCRIPTION
Fix #441 

Tested on a test app: https://biniou.osc-fr1.scalingo.io/#module_pdo_sqlsrv

![image](https://github.com/Scalingo/php-buildpack/assets/1567651/9bacaf68-ab97-4d0e-a335-3892d2d8be7e)

Deployment logs excerpt:

```
[...]
-----> Bundling additional extensions
Installing PECL extension pdo_sqlsrv version 5.12.0
Installing PECL extension sqlsrv version 5.12.0
-----> Installing application dependencies with Composer
[...]
```