### PR TITLE
docs(nodejs): update Node.js spelling in logs

### DIFF
--- a/lib/nodejs
+++ b/lib/nodejs
@@ -6,7 +6,7 @@ function install_node_deps() {
       return 0
   fi
 
-  status "NODE (package.json) app detected"
+  status "Node.js app detected (package.json)"
 
   compile_node $BUILD_DIR $CACHE_DIR
 
@@ -17,7 +17,7 @@ function install_node_deps() {
   ln -s ${BUILD_DIR}/${node_path}/ /app/${node_path}
   ln -s ${BUILD_DIR}/node_modules /app/node_modules
 
-  echo "Node " `node -v` | indent
+  echo "Node.js " $(node --version) | indent
 }
 
 function compile_node() {
@@ -53,12 +53,12 @@ function compile_node() {
   if [ "$semver_range" == "" ]; then
     status "Defaulting to latest stable node: $node_version"
   else
-    status "Requested node range:  $semver_range"
-    status "Resolved node version: $node_version"
+    status "Requested Node.js versions range: $semver_range"
+    status "Resolved Node.js version: $node_version"
   fi
 
   # Download node from Heroku's S3 mirror of nodejs.org/dist
-  status "Downloading and installing node"
+  status "Downloading and installing Node.js"
   node_url="https://heroku-nodebin.s3.us-east-1.amazonaws.com/node/release/linux-x64/node-v${node_version}-linux-x64.tar.gz"
   curl $node_url --location -s -o - | tar xzf - -C $build_dir
 
@@ -90,10 +90,10 @@ function compile_node() {
     test -d $cache_dir/node_modules && cp -r $cache_dir/node_modules $build_dir/
   fi
 
-  status "Installing dependencies"
+  status "Installing Node.js dependencies"
   npm install --production 2>&1 | indent
 
-  status "Pruning unused dependencies"
+  status "Pruning unused Node.js dependencies"
   npm prune 2>&1 | indent
 
   status "Caching node_modules for future builds"


### PR DESCRIPTION
I noticed this while investigating on a support ticket.

I tested on an application and I find it much nicer to read:

```
-----> Node.js app detected (package.json)
-----> Requested Node.js versions range: 20.15.x
-----> Resolved Node.js version: 20.15.1
-----> Downloading and installing Node.js
TIP: Use npm shrinkwrap to lock down dependency versions
-----> package.json unchanged since last build
-----> Restoring node_modules from cache
-----> Installing Node.js dependencies
npm warn config production Use `--omit=dev` instead.

up to date, audited 1 package in 374ms

found 0 vulnerabilities
-----> Pruning unused Node.js dependencies

up to date, audited 1 package in 276ms

found 0 vulnerabilities
-----> Caching node_modules for future builds
-----> Cleaning up node-gyp and npm artifacts
-----> Building runtime environment
Node.js  v20.15.1
```