### PR TITLE
fix(amqp): build amqp PHP ext with librabbitmq 0.15.0

### DIFF
--- a/conf/buildpack.conf
+++ b/conf/buildpack.conf
@@ -34,19 +34,20 @@ zip_version="1.5.2"
 sodium_php72_php73_version="1.0.7"
 
 libmemcached_version="1.0.18"
+# Mandatory for multibytes strings starting with PHP 7.4
+libonig_version="${libonig_version:-6.9.8}"
+librabbitmq_version="0.15.0"
+
 memcached_version="3.3.0"
 gmp_version="6.2.1"
 tidy_version="5.8.0"
 sodium_version="1.0.20"
 coreutils_version="8.32"
 webp_version="${webp_version:-1.3.2}" # Can be found here: https://storage.googleapis.com/downloads.webmproject.org/releases/webp/index.html
-# Mandatory for multibytes strings starting with PHP 7.4
-libonig_version="${libonig_version:-6.9.8}"
 # From https://zlib.net/
 zlib_version="${zlib_version:-1.3.1}"
 igbinary_version="3.2.16"
 mongodb_version="1.20.0"
-librabbitmq_version="0.14.0"
 amqp_version="2.1.2"
 phpredis_version="6.1.0"
 apcu_version="5.1.24"


### PR DESCRIPTION
File has been generated and uploaded to ObjectStorage for `scalingo-22` (`scalingo-20` is stuck to `0.13.0`).
Fix #478 