### PR TITLE
Run composer install before npm install for symfony-ux

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -477,11 +477,11 @@ if [ -n "$PHP_FPM_INCLUDES" ] ; then
     done
 fi
 
+install_composer_deps "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
+
 if [ "$PHP_BUILDPACK_NO_NODE" != "true" ] ; then
   install_node_deps "$BUILD_DIR"
 fi
-
-install_composer_deps "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
 
 # Detect PHP framework
 # Set FRAMEWORK if not set in environment by user


### PR DESCRIPTION
When using `symfony-ux`, the `composer install` command must be run before `npm install` so the JavaScript dependencies can be retrieved in the `vendor/` directory.