### PR TITLE
fix(fpm-config): Move the loading of the fmp.d/* files to after the defaults 

### DIFF
--- a/conf/php/php-fpm.conf
+++ b/conf/php/php-fpm.conf
@@ -6,14 +6,6 @@
 ; prefix. This prefix can be dynamicaly changed by using the
 ; '-p' argument from the command line.
 
-; Include one or more files. If glob(3) exists, it is used to include a bunch of
-; files from a glob(3) pattern. This directive can be used everywhere in the
-; file.
-; Relative path can also be used. They will be prefixed by:
-;  - the global prefix if it's been set (-p arguement)
-;  - the compile-time prefix otherwise
-include=etc/fpm.d/*
-
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;
 ;;;;;;;;;;;;;;;;;;
@@ -493,3 +485,12 @@ decorate_workers_output = no
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p arguement)
+;  - the compile-time prefix otherwise
+include=etc/fpm.d/*


### PR DESCRIPTION
This PR moves the loading of the config files matched `fpm.d/*` to after the default configuration is set.

Before this PR, custom configuration was being overwritten by the defaults.