### PR TITLE
feat(ext-ftp) add ftps support

### DIFF
--- a/support/ext-internal/ftp
+++ b/support/ext-internal/ftp
@@ -9,7 +9,23 @@ pushd $php_src_dir/php-${php_version}/ext/ftp
 export PATH=$PATH:/app/vendor/php/bin
 
 phpize
-./configure --with-ftp
+
+php_series="$(echo $php_version | cut -d '.' -f1,2)"
+if [ -z "$php_series" ]; then
+    echo "Invalid PHP version: $php_version"
+    exit 1
+fi
+
+# For PHP 8.4 and later, use --with-ftp-ssl option
+param=("--enable-ftp")
+if [ ${zend_api_version} -gt 20240000 ]; then
+    param+=("--with-ftp-ssl")
+else
+    param+=("--with-openssl-dir=/usr/include/openssl")
+fi
+
+echo "Configuring FTP extension for PHP $php_version, using './configure $param'"
+./configure "${param[@]}"
 make
 make install
 


### PR DESCRIPTION
Tested with 8.1.33, 8.2.29 and 8.4.10

```sh
root@9ad486d4a55b:/# php --version
PHP 8.1.33 (cli) (built: Jul  3 2025 07:14:18) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.33, Copyright (c) Zend Technologies
    with Zend OPcache v8.1.33, Copyright (c), by Zend Technologies
root@9ad486d4a55b:/# php -r 'ftp_ssl_connect();'

Fatal error: Uncaught ArgumentCountError: ftp_ssl_connect() expects at least 1 argument, 0 given in Command line code:1
Stack trace:
#0 Command line code(1): ftp_ssl_connect()
#1 {main}
  thrown in Command line code on line 1
root@9ad486d4a55b:/# 
```

Fixes #512 