### PR TITLE
fix(libmcrypt): version comes from `buildpack.conf`

### DIFF
--- a/support/get_libmcrypt
+++ b/support/get_libmcrypt
@@ -3,15 +3,10 @@
 set -e
 
 if [ -n "$DEBUG" ]; then
-    set -x
+  set -x
 fi
 
 mcrypt_version="$1"
-
-if [ -z "$mcrypt_version" ]; then
-    echo "Usage: $(basename "$0") VERSION" >&2
-    exit 1
-fi
 
 basedir="$( cd -P "$( dirname "$0" )" && pwd )"
 source "$basedir/../conf/buildpack.conf"


### PR DESCRIPTION
Just like the other `get_*` scripts, the version comes from the `buildpack.conf` file. Hence it's not expected that it's mandatory to provide it on the command line.

e.g.


https://github.com/Scalingo/php-buildpack/blob/0b43d3da43bd6df7413dc6af5f02064c94f9b886/support/get_libonig#L8-L16