### PR TITLE
feat(APCu): release of PHP ext APCu 5.1.27

### DIFF
--- a/conf/versions.sh
+++ b/conf/versions.sh
@@ -44,7 +44,7 @@ igbinary_version="3.2.16"
 mongodb_version="1.21.0"
 amqp_version="2.1.2"
 phpredis_version="6.2.0"
-apcu_version="5.1.26"
+apcu_version="5.1.27"
 newrelic_version="11.5.0.18"
 
 


### PR DESCRIPTION
Related to #526 
Packages have been uploaded to ObjectStorage for:
- `scalingo-22`: PHP `7.4`, `8.1`, `8.2`, `8.3` and `8.4`
- `scalingo-24`: PHP `7.4`, `8.1`, `8.2`, `8.3` and `8.4`