### PR TITLE
chore(openssl): upgrade to OpenSSL 1.1.1w for PHP 7.4.33

### DIFF
--- a/conf/versions.sh
+++ b/conf/versions.sh
@@ -58,4 +58,4 @@ newrelic_version="11.5.0.18"
 pre81_mongodb_version="1.20.1"
 
 # For PHP < 8.1 + scalingo-22 and 24:
-pre81_openssl_version="1.1.1p"
+pre81_openssl_version="1.1.1w"

--- a/support/package_php
+++ b/support/package_php
@@ -125,7 +125,7 @@ php::pkg::openssl::compile() {
 
 	./config \
 		--prefix="${dst_dir}" \
-		--openssldir="${dst_dir}" \
+		--openssldir="/usr/lib/ssl" \
 		> /dev/null
 	make -j 8 > /dev/null
 	make install > /dev/null
@@ -227,7 +227,7 @@ echo "-----> Compiling zlib ${zlib_version}"
 php::pkg::download_extract "${zlib_url}" "${tempdir}" "${tempdir}"
 php::pkg::zlib::compile "${tempdir}/zlib-${zlib_version}" "${zlib_dir}"
 
-echo "-----> Compiling PHP "${php_version}"
+echo "-----> Compiling PHP ${php_version}"
 php::pkg::download_extract "${php_url}" "${tempdir}" "${tempdir}"
 php::pkg::php::compile "${tempdir}/php-${php_version}" "${php_dir}" \
 	"${compile_options[@]}"


### PR DESCRIPTION
Also fixes OPENSSL_DIR, which prevented PHP to find the root CA certs.

Packages have been uploaded to ObjectStorage.