### PR TITLE
feat(composer): release of Composer 2.9.3

### DIFF
--- a/test/defaults
+++ b/test/defaults
@@ -9,13 +9,13 @@ declare -gA latest_composer
 default_php["scalingo-22"]="8.1." # This one depends on the semver stable rule configuration
 default_nginx["scalingo-22"]="1.28."
 default_composer["scalingo-22"]="2.9."
-latest_composer["scalingo-22"]="2.9.2"
+latest_composer["scalingo-22"]="2.9.3"
 
 # Defaults for scalingo-24:
 default_php["scalingo-24"]="8.4."
 default_nginx["scalingo-24"]="1.28."
 default_composer["scalingo-24"]="2.9."
-latest_composer["scalingo-24"]="2.9.2"
+latest_composer["scalingo-24"]="2.9.3"
 
 
 test::defaults::classic() {

--- a/test/fixtures/composer-2.9.3/composer/composer.json
+++ b/test/fixtures/composer-2.9.3/composer/composer.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "paas": {
+            "engines": {
+                "composer": "2.9.3"
+            }
+        }
+    }
+}

--- a/test/fixtures/composer-2.9.3/composer/composer.lock
+++ b/test/fixtures/composer-2.9.3/composer/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "af3bcfef137c4f1a825f32b0b8db68ac",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/test/fixtures/composer-latest
+++ b/test/fixtures/composer-latest
@@ -1,1 +1,1 @@
-composer-2.9.2
+composer-2.9.3


### PR DESCRIPTION
Files have been uploaded to Object Storage:
- For `scalingo-22`: https://semver.scalingo.com/composer-scalingo-22/
- For `scalingo-24`: https://semver.scalingo.com/composer-scalingo-24/

Related to #560 