### PR TITLE
fix(opcache): remove leftover opcache.ini for PHP >= 8.5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -397,6 +397,22 @@ SH
 
 source ".profile.d/php.sh"
 
+# OPCache became a required, statically-built extension in PHP 8.5
+# (https://wiki.php.net/rfc/opcache-required). It can no longer be loaded as
+# an external Zend extension and the shared `opcache.so` file is no longer
+# shipped. PHP >= 8.5 binaries packaged before this conditional was added to
+# `support/package_php` still contain a leftover `etc/conf.d/opcache.ini`
+# with a `zend_extension=opcache.so` directive, which now fails on every PHP
+# invocation with:
+#
+#   PHP Warning:  Failed loading Zend extension 'opcache.so'
+#
+# Remove the obsolete file defensively for PHP >= 8.5 to silence the warning
+# regardless of when the downloaded PHP binary was packaged.
+if [[ "$(php_api_version)" -ge "${PHP_MODULE_API_VERSIONS["8.5"]}" ]]; then
+    rm -f "${VENDORED_PHP}/etc/conf.d/opcache.ini"
+fi
+
 # Lib Oniguruma is only mandatory:
 fetch_package "$PHP_BASE_URL" "libonig-${libonig_version}" /app/vendor/libonig > /dev/null
 export LD_LIBRARY_PATH="/app/vendor/libonig:$LD_LIBRARY_PATH"


### PR DESCRIPTION
## Context

OPCache became a required, statically-built extension in PHP 8.5 ([opcache-required RFC](https://wiki.php.net/rfc/opcache-required)), so it can no longer be loaded as an external Zend extension and the shared `opcache.so` file is no longer shipped.

`support/package_php` was already updated in bcc5875 to stop writing `etc/conf.d/opcache.ini` when packaging PHP >= 8.5.

However, **PHP 8.5 binaries packaged before that fix still contain the
obsolete file**, and they remain the ones currently served to apps using
PHP 8.5.x on `scalingo-22` (the `8.5.6` build for `no-debug-non-zts-20250925`
fetched from the Swift bucket).

## Symptom

Every PHP invocation during build and runtime emits:

```
PHP Warning:  Failed loading Zend extension 'opcache.so'
(tried: /app/vendor/php/lib/php/extensions/no-debug-non-zts-20250925/opcache.so
(/app/vendor/php/lib/php/extensions/no-debug-non-zts-20250925/opcache.so: cannot open shared object file: No such file or directory),
/app/vendor/php/lib/php/extensions/no-debug-non-zts-20250925/opcache.so.so
(/app/vendor/php/lib/php/extensions/no-debug-non-zts-20250925/opcache.so.so: cannot open shared object file: No such file or directory))
in Unknown on line 0
```

This appears for every:
- `composer install` invocation (post-install scripts, `package:discover`, etc.)
- `php artisan` call during build
- Horizon worker startup
- Scheduler tick
- `scalingo run php -m` (which still correctly reports `Zend OPcache` as built-in)

OPCache itself is **active** (built into the binary), so there is no runtime
impact — but the warning pollutes every log line.

## Fix

Remove `${VENDORED_PHP}/etc/conf.d/opcache.ini` defensively in `bin/compile`
when PHP >= 8.5, immediately after `fetch_engine_package php` and after
sourcing `.profile.d/php.sh` (so `php_api_version()` and
`PHP_MODULE_API_VERSIONS` are both available).

This works regardless of whether the downloaded PHP binary was packaged
before or after bcc5875, and is a no-op once the PHP 8.5 binary is
re-released without the file. Behavior for PHP < 8.5 is unchanged.

## Reproduction

Any app declaring `"php": "8.5.*"` in `composer.json` on `scalingo-22`
reproduces the warning during build and runtime.

## Test

Bash syntax checked locally with `bash -n bin/compile`.