### PR TITLE
test: typo in `default_builtins_extensions_*` variables

### DIFF
--- a/test/php82
+++ b/test/php82
@@ -55,7 +55,7 @@ test::php82::extensions::default() {
 	test::utils::compile
 	test::helpers::enter_prod
 
-	local extensions=("${default_builtin_extensions_82[@]}")
+	local extensions=("${default_builtins_extensions_82[@]}")
 	extensions+=("${default_pecl_extensions_82[@]}")
 
 	test::helpers::enabled_extensions "${extensions[@]}"

--- a/test/php83
+++ b/test/php83
@@ -55,7 +55,7 @@ test::php83::extensions::default() {
 	test::utils::compile
 	test::helpers::enter_prod
 
-	local extensions=("${default_builtin_extensions_83[@]}")
+	local extensions=("${default_builtins_extensions_83[@]}")
 	extensions+=("${default_pecl_extensions_83[@]}")
 
 	test::helpers::enabled_extensions "${extensions[@]}"

--- a/test/php84
+++ b/test/php84
@@ -55,7 +55,7 @@ test::php84::extensions::default() {
 	test::utils::compile
 	test::helpers::enter_prod
 
-	local extensions=("${default_builtin_extensions_84[@]}")
+	local extensions=("${default_builtins_extensions_84[@]}")
 	extensions+=("${default_pecl_extensions_84[@]}")
 
 	test::helpers::enabled_extensions "${extensions[@]}"
@@ -74,4 +74,3 @@ test::php84::extensions::optional_builtin() {
 
 	test::helpers::enabled_extensions "${optional_builtin_extensions_84[@]}"
 }
-

--- a/test/php85
+++ b/test/php85
@@ -55,7 +55,7 @@ test::php85::extensions::default() {
 	test::utils::compile
 	test::helpers::enter_prod
 
-	local extensions=("${default_builtin_extensions_85[@]}")
+	local extensions=("${default_builtins_extensions_85[@]}")
 	extensions+=("${default_pecl_extensions_85[@]}")
 
 	test::helpers::enabled_extensions "${extensions[@]}"
@@ -74,4 +74,3 @@ test::php85::extensions::optional_builtin() {
 
 	test::helpers::enabled_extensions "${optional_builtin_extensions_85[@]}"
 }
-


### PR DESCRIPTION
The variable is declared at the beginning of each file and is named `default_builtins_extensions_*`. But when using it we name it `default_builtin_extensions_*` (missing `s`). Hence this test never worked.