### PR TITLE
fix(datadog): Use correct variable name in Datadog install script

### DIFF
--- a/lib/datadog
+++ b/lib/datadog
@@ -15,7 +15,7 @@ function install_datadog() {
     local cwd=$(pwd)
     local temp_dir=$(mktmpdir "datadog")
 
-    cd "${tempdir}"
+    cd "${temp_dir}"
 
     curl --silent -L "https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php" > datadog-setup.php
     mkdir -p ${install_dir}


### PR DESCRIPTION
fixes https://github.com/Scalingo/php-buildpack/issues/608

Corrected the variable name from `tempdir` to `temp_dir` to match the declared variable and avoid undefined behavior (and a crash on stack `scalingo-26`).

Not sure why this was working until now :upside_down_face: I guess `tempdir` was refering to a global variable defined outside of this script.